### PR TITLE
Add Auth `ConfigMap` management variables

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,8 @@ module "eks" {
   create_node_security_group = true
 
   # aws-auth configmap
-  manage_aws_auth_configmap               = true
+  create_aws_auth_configmap               = var.create_aws_auth_configmap
+  manage_aws_auth_configmap               = var.manage_aws_auth_configmap
   aws_auth_node_iam_role_arns_non_windows = [aws_iam_role.workers.arn]
   aws_auth_roles                          = var.role_mapping
   aws_auth_users                          = var.user_mapping

--- a/variables.tf
+++ b/variables.tf
@@ -49,7 +49,7 @@ variable "workers_iam_boundary" {
 }
 
 #######################
-# Cluster RBAC (AWS Auth) 
+# Cluster RBAC (AWS Auth)
 #######################
 
 # For Self managed nodes groups set the create_aws_auth to true

--- a/variables.tf
+++ b/variables.tf
@@ -49,8 +49,22 @@ variable "workers_iam_boundary" {
 }
 
 #######################
-# Cluster RBAC (AWS Auth)
+# Cluster RBAC (AWS Auth) 
 #######################
+
+# For Self managed nodes groups set the create_aws_auth to true
+variable "create_aws_auth_configmap" {
+  description = "Determines whether to create the aws-auth configmap. NOTE - this is only intended for scenarios where the configmap does not exist (i.e. - when using only self-managed node groups). Most users should use `manage_aws_auth_configmap`"
+  type        = bool
+  default     = true
+}
+
+variable "manage_aws_auth_configmap" {
+  description = "Determines whether to manage the aws-auth configmap"
+  type        = bool
+  default     = false
+}
+
 variable "role_mapping" {
   description = "List of IAM roles to give access to the EKS cluster"
   type = list(object({


### PR DESCRIPTION
Modified the main.tf to add the below line 68 for the aws_auth creation. This argument was missing so it was not creating the aws-auth config file. Now i tested and its fixed.

create_aws_auth_configmap               = true

Please verify and approve.