### PR TITLE
Feature/access to webhook port

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ provider "helm" {
 | <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | Base64 Encoded Cluster CA Data |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | Endpoint of the EKS Cluster |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | EKS Cluster name created |
+| <a name="output_cluster_oidc_issuer_url"></a> [cluster\_oidc\_issuer\_url](#output\_cluster\_oidc\_issuer\_url) | The URL on the EKS cluster for the OpenID Connect identity provider |
 | <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | Security Group ID of the master nodes |
 | <a name="output_ebs_kms_key_arn"></a> [ebs\_kms\_key\_arn](#output\_ebs\_kms\_key\_arn) | KMS Key ARN used for EBS encryption |
 | <a name="output_ebs_kms_key_id"></a> [ebs\_kms\_key\_id](#output\_ebs\_kms\_key\_id) | KMS Key ID used for EBS encryption |

--- a/main.tf
+++ b/main.tf
@@ -49,6 +49,14 @@ module "eks" {
       cidr_blocks      = ["0.0.0.0/0"]
       ipv6_cidr_blocks = ["::/0"]
     }
+    ingress_allow_access_from_control_plane = {
+      type                          = "ingress"
+      protocol                      = "tcp"
+      from_port                     = 9443
+      to_port                       = 9443
+      source_cluster_security_group = true
+      description                   = "Allow access from control plane to webhook port of AWS load balancer controller"
+    }
   }, var.node_security_group_additional_rules)
 
   cluster_encryption_config = [{

--- a/modules/self_managed_nodes/README.md
+++ b/modules/self_managed_nodes/README.md
@@ -46,8 +46,8 @@ the type of images:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.16.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.7.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.7 |
 
 ## Modules
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -28,6 +28,11 @@ output "oidc_provider_arn" {
   value       = module.eks.oidc_provider_arn
 }
 
+output "cluster_oidc_issuer_url" {
+  description = "The URL on the EKS cluster for the OpenID Connect identity provider"
+  value       = module.eks.cluster_oidc_issuer_url
+}
+
 output "cluster_name" {
   description = "EKS Cluster name created"
   value       = module.eks.cluster_id


### PR DESCRIPTION
- [x] cluster_oidc_issuer_url --> this is for the lb-controller v0.4.0
- [x] [Ensure worker nodes security group permit access to TCP port 9443 from the kubernetes control plane for the webhook access.](https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/deploy/installation.md#:~:text=!!!note%20%22security%20group%20configuration%22%20If%20you%20do%20not%20use%20eksctl%2C%20you%20need%20to%20ensure%20worker%20nodes%20security%20group%20permit%20access%20to%20TCP%20port%209443%20from%20the%20kubernetes%20control%20plane%20for%20the%20webhook%20access.)