### PR TITLE
[BREAKING] Switch default nodes to eks managed node groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ provider "helm" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
 
 ## Modules
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ provider "helm" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
 
 ## Modules
 
@@ -121,21 +121,17 @@ provider "helm" {
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 18.26.0 |
 | <a name="module_kms_ebs"></a> [kms\_ebs](#module\_kms\_ebs) | SPHTech-Platform/kms/aws | ~> 0.1.0 |
 | <a name="module_kms_secret"></a> [kms\_secret](#module\_kms\_secret) | SPHTech-Platform/kms/aws | ~> 0.1.0 |
-| <a name="module_node_groups"></a> [node\_groups](#module\_node\_groups) | ./modules/self_managed_nodes | n/a |
-| <a name="module_node_termination_handler_sqs"></a> [node\_termination\_handler\_sqs](#module\_node\_termination\_handler\_sqs) | terraform-aws-modules/sqs/aws | ~> 3.0 |
+| <a name="module_node_groups"></a> [node\_groups](#module\_node\_groups) | ./modules/eks_managed_nodes | n/a |
 | <a name="module_vpc_cni_irsa_role"></a> [vpc\_cni\_irsa\_role](#module\_vpc\_cni\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 4.21.1 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
-| [aws_cloudwatch_event_rule.node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
-| [aws_cloudwatch_event_target.node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_eks_addon.coredns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.ebs_csi](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.kube_proxy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
 | [aws_eks_addon.vpc_cni](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eks_addon) | resource |
-| [aws_iam_instance_profile.workers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
 | [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.workers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.ebs_csi_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
@@ -149,7 +145,6 @@ provider "helm" {
 | [aws_iam_policy_document.eks_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_csi_ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.node_termination_handler_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_subnet.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
@@ -171,13 +166,15 @@ provider "helm" {
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS Cluster Version | `string` | `"1.22"` | no |
 | <a name="input_create_aws_auth_configmap"></a> [create\_aws\_auth\_configmap](#input\_create\_aws\_auth\_configmap) | Determines whether to create the aws-auth configmap. NOTE - this is only intended for scenarios where the configmap does not exist (i.e. - when using only self-managed node groups). Most users should use `manage_aws_auth_configmap` | `bool` | `true` | no |
 | <a name="input_default_group_ami_id"></a> [default\_group\_ami\_id](#input\_default\_group\_ami\_id) | The AMI from which to launch the defualt group instance. If not supplied, EKS will use its own default image | `string` | `""` | no |
-| <a name="input_default_group_instance_type"></a> [default\_group\_instance\_type](#input\_default\_group\_instance\_type) | Instance type for the default node group | `string` | `"m5a.xlarge"` | no |
+| <a name="input_default_group_instance_types"></a> [default\_group\_instance\_types](#input\_default\_group\_instance\_types) | Instance type for the default node group | `list(string)` | <pre>[<br>  "m5a.xlarge",<br>  "m5.xlarge",<br>  "m5n.xlarge",<br>  "m5zn.xlarge"<br>]</pre> | no |
 | <a name="input_default_group_launch_template_name"></a> [default\_group\_launch\_template\_name](#input\_default\_group\_launch\_template\_name) | Name of the default node group launch template | `string` | `"default"` | no |
 | <a name="input_default_group_max_size"></a> [default\_group\_max\_size](#input\_default\_group\_max\_size) | Configuration for max default node group size | `number` | `5` | no |
 | <a name="input_default_group_min_size"></a> [default\_group\_min\_size](#input\_default\_group\_min\_size) | Configuration for min default node group size | `number` | `1` | no |
 | <a name="input_default_group_name"></a> [default\_group\_name](#input\_default\_group\_name) | Name of the default node group | `string` | `"default"` | no |
 | <a name="input_default_group_subnet_ids"></a> [default\_group\_subnet\_ids](#input\_default\_group\_subnet\_ids) | Subnet IDs to create the default group ASGs in | `list(string)` | `[]` | no |
 | <a name="input_default_group_volume_size"></a> [default\_group\_volume\_size](#input\_default\_group\_volume\_size) | Size of the persistentence volume for the default group | `number` | `50` | no |
+| <a name="input_eks_managed_node_group_defaults"></a> [eks\_managed\_node\_group\_defaults](#input\_eks\_managed\_node\_group\_defaults) | Map of EKS managed node group default configurations | `any` | <pre>{<br>  "create_iam_role": false,<br>  "create_security_group": false,<br>  "disk_size": 50,<br>  "ebs_optimized": true,<br>  "enable_monitoring": true,<br>  "metadata_options": {<br>    "http_endpoint": "enabled",<br>    "http_put_response_hop_limit": 1,<br>    "http_tokens": "required",<br>    "instance_metadata_tags": "disabled"<br>  },<br>  "protect_from_scale_in": false,<br>  "update_launch_template_default_version": true<br>}</pre> | no |
+| <a name="input_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#input\_eks\_managed\_node\_groups) | Map of EKS managed node group definitions to create | `any` | `{}` | no |
 | <a name="input_enable_cluster_windows_support"></a> [enable\_cluster\_windows\_support](#input\_enable\_cluster\_windows\_support) | Determines whether to create the amazon-vpc-cni configmap and windows worker roles into aws-auth. | `bool` | `false` | no |
 | <a name="input_force_imdsv2"></a> [force\_imdsv2](#input\_force\_imdsv2) | Force IMDSv2 metadata server. | `bool` | `true` | no |
 | <a name="input_force_irsa"></a> [force\_irsa](#input\_force\_irsa) | Force usage of IAM Roles for Service Account | `bool` | `true` | no |
@@ -189,8 +186,6 @@ provider "helm" {
 | <a name="input_node_termination_handler_sqs_name"></a> [node\_termination\_handler\_sqs\_name](#input\_node\_termination\_handler\_sqs\_name) | Override the name for the SQS used in Node Termination Handler | `string` | `""` | no |
 | <a name="input_only_critical_addons_enabled"></a> [only\_critical\_addons\_enabled](#input\_only\_critical\_addons\_enabled) | Enabling this option will taint default node group with CriticalAddonsOnly=true:NoSchedule taint. Changing this forces a new resource to be created. | `bool` | `false` | no |
 | <a name="input_role_mapping"></a> [role\_mapping](#input\_role\_mapping) | List of IAM roles to give access to the EKS cluster | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
-| <a name="input_self_managed_node_group_defaults"></a> [self\_managed\_node\_group\_defaults](#input\_self\_managed\_node\_group\_defaults) | Map of self-managed node group default configurations | `any` | <pre>{<br>  "create_iam_role": false,<br>  "create_security_group": false,<br>  "disk_size": 50,<br>  "instance_refresh": {<br>    "strategy": "Rolling"<br>  },<br>  "metadata_options": {<br>    "http_endpoint": "enabled",<br>    "http_put_response_hop_limit": 1,<br>    "http_tokens": "required",<br>    "instance_metadata_tags": "disabled"<br>  },<br>  "protect_from_scale_in": false,<br>  "update_launch_template_default_version": true<br>}</pre> | no |
-| <a name="input_self_managed_node_groups"></a> [self\_managed\_node\_groups](#input\_self\_managed\_node\_groups) | Map of self-managed node group definitions to create | `any` | `{}` | no |
 | <a name="input_skip_asg_role"></a> [skip\_asg\_role](#input\_skip\_asg\_role) | Skip creating ASG Service Linked Role if it's already created | `bool` | `false` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of subnet IDs where the EKS cluster (ENIs) will be provisioned along with the nodes/node groups. Node groups can be deployed within a different set of subnet IDs from within the node group configuration | `list(string)` | n/a | yes |
 | <a name="input_user_mapping"></a> [user\_mapping](#input\_user\_mapping) | List of IAM Users to give access to the EKS Cluster | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | `[]` | no |
@@ -209,9 +204,7 @@ provider "helm" {
 | <a name="output_cluster_security_group_id"></a> [cluster\_security\_group\_id](#output\_cluster\_security\_group\_id) | Security Group ID of the master nodes |
 | <a name="output_ebs_kms_key_arn"></a> [ebs\_kms\_key\_arn](#output\_ebs\_kms\_key\_arn) | KMS Key ARN used for EBS encryption |
 | <a name="output_ebs_kms_key_id"></a> [ebs\_kms\_key\_id](#output\_ebs\_kms\_key\_id) | KMS Key ID used for EBS encryption |
-| <a name="output_node_termination_handler_sqs_arn"></a> [node\_termination\_handler\_sqs\_arn](#output\_node\_termination\_handler\_sqs\_arn) | ARN of the SQS queue used to handle node termination events |
 | <a name="output_oidc_provider_arn"></a> [oidc\_provider\_arn](#output\_oidc\_provider\_arn) | OIDC Provider ARN for IRSA |
-| <a name="output_worker_iam_instance_profile_arn"></a> [worker\_iam\_instance\_profile\_arn](#output\_worker\_iam\_instance\_profile\_arn) | IAM Instance Profile ARN to use for worker nodes |
 | <a name="output_worker_iam_role_arn"></a> [worker\_iam\_role\_arn](#output\_worker\_iam\_role\_arn) | IAM Role ARN used by worker nodes |
 | <a name="output_worker_iam_role_name"></a> [worker\_iam\_role\_name](#output\_worker\_iam\_role\_name) | IAM Role Name used by worker nodes |
 | <a name="output_worker_security_group_id"></a> [worker\_security\_group\_id](#output\_worker\_security\_group\_id) | Security Group ID of the worker nodes |

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ provider "helm" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 4.21.1 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 18.26.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 18.29.0 |
 | <a name="module_kms_ebs"></a> [kms\_ebs](#module\_kms\_ebs) | SPHTech-Platform/kms/aws | ~> 0.1.0 |
 | <a name="module_kms_secret"></a> [kms\_secret](#module\_kms\_secret) | SPHTech-Platform/kms/aws | ~> 0.1.0 |
 | <a name="module_node_groups"></a> [node\_groups](#module\_node\_groups) | ./modules/eks_managed_nodes | n/a |

--- a/iam.tf
+++ b/iam.tf
@@ -40,15 +40,6 @@ resource "aws_iam_role" "workers" {
   force_detach_policies = true
 }
 
-resource "aws_iam_instance_profile" "workers" {
-  role = aws_iam_role.workers.name
-  name = coalesce(var.workers_iam_role, "${var.cluster_name}-workers")
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
 resource "aws_iam_role_policy_attachment" "workers" {
   for_each = toset(compact(distinct(concat([
     "${local.policy_arn_prefix}/AmazonEKSWorkerNodePolicy",

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 18.26.0"
+  version = "~> 18.29.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/modules/eks_managed_nodes/README.md
+++ b/modules/eks_managed_nodes/README.md
@@ -23,6 +23,7 @@
 | Name | Type |
 |------|------|
 | [aws_autoscaling_group_tag.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group_tag) | resource |
+| [aws_ami.eks_default_bottlerocket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_subnet.subnets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
 
@@ -33,6 +34,7 @@
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster name | `string` | n/a | yes |
 | <a name="input_cluster_security_group_id"></a> [cluster\_security\_group\_id](#input\_cluster\_security\_group\_id) | Security Group ID of the master nodes | `string` | n/a | yes |
 | <a name="input_cluster_service_ipv4_cidr"></a> [cluster\_service\_ipv4\_cidr](#input\_cluster\_service\_ipv4\_cidr) | The CIDR block to assign Kubernetes service IP addresses from. If you don't specify a block, Kubernetes assigns addresses from either the 10.100.0.0/16 or 172.20.0.0/16 CIDR blocks | `string` | `null` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | EKS Cluster Version | `string` | `"1.22"` | no |
 | <a name="input_eks_managed_node_group_defaults"></a> [eks\_managed\_node\_group\_defaults](#input\_eks\_managed\_node\_group\_defaults) | Map of EKS managed node group default configurations | `any` | <pre>{<br>  "create_iam_role": false,<br>  "create_security_group": false,<br>  "ebs_optimized": true,<br>  "enable_monitoring": true,<br>  "protect_from_scale_in": false,<br>  "update_launch_template_default_version": true<br>}</pre> | no |
 | <a name="input_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#input\_eks\_managed\_node\_groups) | Map of EKS managed node group definitions to create | `any` | `{}` | no |
 | <a name="input_force_imdsv2"></a> [force\_imdsv2](#input\_force\_imdsv2) | Force IMDSv2 metadata server. | `bool` | `true` | no |

--- a/modules/eks_managed_nodes/README.md
+++ b/modules/eks_managed_nodes/README.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_eks_managed_node_group"></a> [eks\_managed\_node\_group](#module\_eks\_managed\_node\_group) | terraform-aws-modules/eks/aws//modules/eks-managed-node-group | ~> 18.26.0 |
+| <a name="module_eks_managed_node_group"></a> [eks\_managed\_node\_group](#module\_eks\_managed\_node\_group) | terraform-aws-modules/eks/aws//modules/eks-managed-node-group | ~> 18.29.0 |
 
 ## Resources
 

--- a/modules/eks_managed_nodes/README.md
+++ b/modules/eks_managed_nodes/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
 
 ## Modules
 

--- a/modules/eks_managed_nodes/README.md
+++ b/modules/eks_managed_nodes/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
 
 ## Modules
 

--- a/modules/eks_managed_nodes/data.tf
+++ b/modules/eks_managed_nodes/data.tf
@@ -11,3 +11,13 @@ data "aws_subnet" "subnets" {
 
   id = each.key
 }
+
+data "aws_ami" "eks_default_bottlerocket" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["bottlerocket-aws-k8s-${var.cluster_version}-x86_64-*"]
+  }
+}

--- a/modules/eks_managed_nodes/main.tf
+++ b/modules/eks_managed_nodes/main.tf
@@ -36,7 +36,7 @@ locals {
 ################################################################################
 module "eks_managed_node_group" {
   source  = "terraform-aws-modules/eks/aws//modules/eks-managed-node-group"
-  version = "~> 18.26.0"
+  version = "~> 18.29.0"
 
   for_each = local.eks_managed_node_groups
 

--- a/modules/eks_managed_nodes/main.tf
+++ b/modules/eks_managed_nodes/main.tf
@@ -1,10 +1,27 @@
 locals {
   eks_managed_node_group_defaults = merge(
     {
-      create_iam_role = false
-      iam_role_arn    = var.worker_iam_role_arn
-      platform        = "bottlerocket"
-      ami_id          = data.aws_ami.eks_default_bottlerocket.id
+      create_iam_role      = false
+      iam_role_arn         = var.worker_iam_role_arn
+      platform             = "bottlerocket"
+      ami_id               = data.aws_ami.eks_default_bottlerocket.id
+      bootstrap_extra_args = <<-EOT
+      # The admin host container provides SSH access and runs with "superpowers".
+      # It is disabled by default, but can be disabled explicitly.
+      [settings.host-containers.admin]
+      enabled = false
+      # The control host container provides out-of-band access via SSM.
+      # It is enabled by default, and can be disabled if you do not expect to use SSM.
+      # This could leave you with no way to access the API and change settings on an existing node!
+      [settings.host-containers.control]
+      enabled = true
+      [settings.kubernetes.node-labels]
+      "bottlerocket.aws/updater-interface-version" = "2.0.0"
+      EOT
+
+      labels = {
+        "bottlerocket.aws/updater-interface-version" = "2.0.0"
+      }
     },
     var.eks_managed_node_group_defaults
   )

--- a/modules/eks_managed_nodes/main.tf
+++ b/modules/eks_managed_nodes/main.tf
@@ -3,6 +3,8 @@ locals {
     {
       create_iam_role = false
       iam_role_arn    = var.worker_iam_role_arn
+      platform        = "bottlerocket"
+      ami_id          = data.aws_ami.eks_default_bottlerocket.id
     },
     var.eks_managed_node_group_defaults
   )

--- a/modules/eks_managed_nodes/variables.tf
+++ b/modules/eks_managed_nodes/variables.tf
@@ -12,6 +12,12 @@ variable "cluster_name" {
   type        = string
 }
 
+variable "cluster_version" {
+  description = "EKS Cluster Version"
+  type        = string
+  default     = "1.22"
+}
+
 variable "worker_iam_role_arn" {
   description = "Worker Nodes IAM Role ARN"
   type        = string

--- a/modules/essentials/README.md
+++ b/modules/essentials/README.md
@@ -59,9 +59,9 @@ module "eks_essentials" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.2 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
 
 ## Modules
 
@@ -69,11 +69,14 @@ module "eks_essentials" {
 |------|--------|---------|
 | <a name="module_cluster_autoscaler_irsa_role"></a> [cluster\_autoscaler\_irsa\_role](#module\_cluster\_autoscaler\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 4.21.1 |
 | <a name="module_node_termination_handler_irsa"></a> [node\_termination\_handler\_irsa](#module\_node\_termination\_handler\_irsa) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 4.21.1 |
+| <a name="module_node_termination_handler_sqs"></a> [node\_termination\_handler\_sqs](#module\_node\_termination\_handler\_sqs) | terraform-aws-modules/sqs/aws | ~> 3.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_event_rule.node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
+| [aws_cloudwatch_event_target.node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) | resource |
 | [aws_ecr_pull_through_cache_rule.cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_pull_through_cache_rule) | resource |
 | [aws_iam_policy.ecr_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.worker_ecr_pullthrough](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -88,6 +91,7 @@ module "eks_essentials" {
 | [aws_eks_cluster.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
 | [aws_eks_cluster_auth.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_iam_policy_document.ecr_cache](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.node_termination_handler_sqs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_sqs_queue.node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sqs_queue) | data source |
 
@@ -119,6 +123,7 @@ module "eks_essentials" {
 | <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster name | `string` | n/a | yes |
 | <a name="input_configure_ecr_pull_through"></a> [configure\_ecr\_pull\_through](#input\_configure\_ecr\_pull\_through) | Configure ECR Pull Through Cache. | `bool` | `true` | no |
 | <a name="input_coredns_pdb_min_available"></a> [coredns\_pdb\_min\_available](#input\_coredns\_pdb\_min\_available) | PDB min available CoreDNS pods. | `number` | `1` | no |
+| <a name="input_create_node_termination_handler_sqs"></a> [create\_node\_termination\_handler\_sqs](#input\_create\_node\_termination\_handler\_sqs) | Whether to create node\_termination\_handler\_sqs. | `bool` | `false` | no |
 | <a name="input_csi_allow_volume_expansion"></a> [csi\_allow\_volume\_expansion](#input\_csi\_allow\_volume\_expansion) | Allow volume expansion in the StorageClass for CSI. Can be true or false | `bool` | `true` | no |
 | <a name="input_csi_default_storage_class"></a> [csi\_default\_storage\_class](#input\_csi\_default\_storage\_class) | Set the CSI StorageClass as the default storage class | `bool` | `true` | no |
 | <a name="input_csi_encryption_enable"></a> [csi\_encryption\_enable](#input\_csi\_encryption\_enable) | Enable encryption for CSI Storage Class | `bool` | `true` | no |
@@ -138,6 +143,7 @@ module "eks_essentials" {
 | <a name="input_node_termination_handler_chart_version"></a> [node\_termination\_handler\_chart\_version](#input\_node\_termination\_handler\_chart\_version) | Chart version for Node Termination Handler | `string` | `"0.17.0"` | no |
 | <a name="input_node_termination_handler_cordon_only"></a> [node\_termination\_handler\_cordon\_only](#input\_node\_termination\_handler\_cordon\_only) | Cordon but do not drain nodes upon spot interruption termination notice | `bool` | `false` | no |
 | <a name="input_node_termination_handler_dry_run"></a> [node\_termination\_handler\_dry\_run](#input\_node\_termination\_handler\_dry\_run) | Only log calls to kubernetes control plane | `bool` | `false` | no |
+| <a name="input_node_termination_handler_enable"></a> [node\_termination\_handler\_enable](#input\_node\_termination\_handler\_enable) | Enable node\_termination\_handler creation. Only needed for self managed node groups. | `bool` | `false` | no |
 | <a name="input_node_termination_handler_iam_role"></a> [node\_termination\_handler\_iam\_role](#input\_node\_termination\_handler\_iam\_role) | Override the name of the Node Termination Handler IAM Role | `string` | `""` | no |
 | <a name="input_node_termination_handler_image"></a> [node\_termination\_handler\_image](#input\_node\_termination\_handler\_image) | Docker image for Node Termination Handler | `string` | `"public.ecr.aws/aws-ec2/aws-node-termination-handler"` | no |
 | <a name="input_node_termination_handler_json_logging"></a> [node\_termination\_handler\_json\_logging](#input\_node\_termination\_handler\_json\_logging) | Log messages in JSON format | `bool` | `true` | no |
@@ -149,8 +155,10 @@ module "eks_essentials" {
 | <a name="input_node_termination_handler_replicas"></a> [node\_termination\_handler\_replicas](#input\_node\_termination\_handler\_replicas) | Number of replicas for Node Termination Handler | `number` | `1` | no |
 | <a name="input_node_termination_handler_resources"></a> [node\_termination\_handler\_resources](#input\_node\_termination\_handler\_resources) | Resources for Node Termination Handler | `any` | <pre>{<br>  "limits": {<br>    "cpu": "100m",<br>    "memory": "100Mi"<br>  },<br>  "requests": {<br>    "cpu": "10m",<br>    "memory": "100Mi"<br>  }<br>}</pre> | no |
 | <a name="input_node_termination_handler_scheduled_event_draining_enabled"></a> [node\_termination\_handler\_scheduled\_event\_draining\_enabled](#input\_node\_termination\_handler\_scheduled\_event\_draining\_enabled) | Drain nodes before the maintenance window starts for an EC2 instance scheduled event | `bool` | `false` | no |
+| <a name="input_node_termination_handler_spot_event_name"></a> [node\_termination\_handler\_spot\_event\_name](#input\_node\_termination\_handler\_spot\_event\_name) | Override name of the Cloudwatch Event to handle spot termination of nodes | `string` | `""` | no |
 | <a name="input_node_termination_handler_spot_interruption_draining_enabled"></a> [node\_termination\_handler\_spot\_interruption\_draining\_enabled](#input\_node\_termination\_handler\_spot\_interruption\_draining\_enabled) | Drain nodes when the spot interruption termination notice is received | `bool` | `true` | no |
-| <a name="input_node_termination_handler_sqs_arn"></a> [node\_termination\_handler\_sqs\_arn](#input\_node\_termination\_handler\_sqs\_arn) | ARN of the SQS used in Node Termination Handler | `string` | n/a | yes |
+| <a name="input_node_termination_handler_sqs_arn"></a> [node\_termination\_handler\_sqs\_arn](#input\_node\_termination\_handler\_sqs\_arn) | ARN of the SQS used in Node Termination Handler | `string` | `null` | no |
+| <a name="input_node_termination_handler_sqs_name"></a> [node\_termination\_handler\_sqs\_name](#input\_node\_termination\_handler\_sqs\_name) | Override the name for the SQS used in Node Termination Handler | `string` | `""` | no |
 | <a name="input_node_termination_handler_tag"></a> [node\_termination\_handler\_tag](#input\_node\_termination\_handler\_tag) | Docker image tag for Node Termination Handler. This should correspond to the Kubernetes version | `string` | `"v1.16.0"` | no |
 | <a name="input_node_termination_handler_taint_node"></a> [node\_termination\_handler\_taint\_node](#input\_node\_termination\_handler\_taint\_node) | Taint node upon spot interruption termination notice | `bool` | `true` | no |
 | <a name="input_node_termination_iam_role"></a> [node\_termination\_iam\_role](#input\_node\_termination\_iam\_role) | Name of the IAM Role for Node Termination Handler | `string` | `"bedrock_node_termination_handler"` | no |
@@ -163,5 +171,7 @@ module "eks_essentials" {
 
 ## Outputs
 
-No outputs.
+| Name | Description |
+|------|-------------|
+| <a name="output_node_termination_handler_sqs_arn"></a> [node\_termination\_handler\_sqs\_arn](#output\_node\_termination\_handler\_sqs\_arn) | ARN of the SQS queue used to handle node termination events |
 <!-- END_TF_DOCS -->

--- a/modules/essentials/README.md
+++ b/modules/essentials/README.md
@@ -59,9 +59,9 @@ module "eks_essentials" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.6.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.13.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.2 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.10 |
 
 ## Modules
 

--- a/modules/essentials/data.tf
+++ b/modules/essentials/data.tf
@@ -15,7 +15,7 @@ data "aws_region" "current" {
 data "aws_arn" "node_termination_handler_sqs" {
   count = var.node_termination_handler_enable ? 1 : 0
 
-  arn = var.node_termination_handler_sqs_arn
+  arn = try(module.node_termination_handler_sqs[0].sqs_queue_arn, var.node_termination_handler_sqs_arn)
 }
 
 data "aws_sqs_queue" "node_termination_handler" {

--- a/modules/essentials/data.tf
+++ b/modules/essentials/data.tf
@@ -13,13 +13,13 @@ data "aws_region" "current" {
 }
 
 data "aws_arn" "node_termination_handler_sqs" {
-  count = var.node_termination_handler_sqs_arn != null ? 1 : 0
+  count = var.node_termination_handler_enable ? 1 : 0
 
   arn = var.node_termination_handler_sqs_arn
 }
 
 data "aws_sqs_queue" "node_termination_handler" {
-  count = var.node_termination_handler_sqs_arn != null ? 1 : 0
+  count = var.node_termination_handler_enable ? 1 : 0
 
   name = data.aws_arn.node_termination_handler_sqs[0].resource
 }

--- a/modules/essentials/data.tf
+++ b/modules/essentials/data.tf
@@ -13,9 +13,13 @@ data "aws_region" "current" {
 }
 
 data "aws_arn" "node_termination_handler_sqs" {
+  count = var.node_termination_handler_sqs_arn != null ? 1 : 0
+
   arn = var.node_termination_handler_sqs_arn
 }
 
 data "aws_sqs_queue" "node_termination_handler" {
-  name = data.aws_arn.node_termination_handler_sqs.resource
+  count = var.node_termination_handler_sqs_arn != null ? 1 : 0
+
+  name = data.aws_arn.node_termination_handler_sqs[0].resource
 }

--- a/modules/essentials/node_termination_handler.tf
+++ b/modules/essentials/node_termination_handler.tf
@@ -20,7 +20,7 @@ locals {
     service_account = var.node_termination_service_account
     iam_role_arn    = var.node_termination_handler_enable ? module.node_termination_handler_irsa[0].iam_role_arn : ""
 
-    sqs_queue_url = data.aws_sqs_queue.node_termination_handler.url
+    sqs_queue_url = data.aws_sqs_queue.node_termination_handler[0].url
 
     replicas          = var.node_termination_handler_replicas
     pdb_min_available = var.node_termination_handler_pdb_min_available

--- a/modules/essentials/node_termination_handler.tf
+++ b/modules/essentials/node_termination_handler.tf
@@ -20,7 +20,7 @@ locals {
     service_account = var.node_termination_service_account
     iam_role_arn    = var.node_termination_handler_enable ? module.node_termination_handler_irsa[0].iam_role_arn : ""
 
-    sqs_queue_url = data.aws_sqs_queue.node_termination_handler[0].url
+    sqs_queue_url = var.node_termination_handler_enable ? data.aws_sqs_queue.node_termination_handler[0].url : ""
 
     replicas          = var.node_termination_handler_replicas
     pdb_min_available = var.node_termination_handler_pdb_min_available

--- a/modules/essentials/node_termination_handler.tf
+++ b/modules/essentials/node_termination_handler.tf
@@ -18,7 +18,7 @@ locals {
     dry_run                    = var.node_termination_handler_dry_run
 
     service_account = var.node_termination_service_account
-    iam_role_arn    = module.node_termination_handler_irsa.iam_role_arn
+    iam_role_arn    = var.node_termination_handler_enable ? module.node_termination_handler_irsa[0].iam_role_arn : ""
 
     sqs_queue_url = data.aws_sqs_queue.node_termination_handler.url
 
@@ -28,6 +28,8 @@ locals {
 }
 
 resource "helm_release" "node_termination_handler" {
+  count = var.node_termination_handler_enable ? 1 : 0
+
   name       = var.node_termination_handler_release_name
   chart      = var.node_termination_handler_chart_name
   repository = var.node_termination_handler_chart_repository_url
@@ -42,6 +44,8 @@ resource "helm_release" "node_termination_handler" {
 }
 
 module "node_termination_handler_irsa" {
+  count = var.node_termination_handler_enable ? 1 : 0
+
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 4.21.1"
 

--- a/modules/essentials/outputs.tf
+++ b/modules/essentials/outputs.tf
@@ -1,0 +1,4 @@
+output "node_termination_handler_sqs_arn" {
+  description = "ARN of the SQS queue used to handle node termination events"
+  value       = try(module.node_termination_handler_sqs[0].sqs_queue_arn, "")
+}

--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -367,6 +367,7 @@ variable "node_termination_handler_permissions_boundary" {
 variable "node_termination_handler_sqs_arn" {
   description = "ARN of the SQS used in Node Termination Handler"
   type        = string
+  default     = ""
 }
 
 variable "node_termination_handler_release_name" {

--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -352,6 +352,24 @@ variable "node_termination_handler_enable" {
   default     = false
 }
 
+variable "create_node_termination_handler_sqs" {
+  description = "Whether to create node_termination_handler_sqs."
+  type        = bool
+  default     = false
+}
+
+variable "node_termination_handler_sqs_name" {
+  description = "Override the name for the SQS used in Node Termination Handler"
+  type        = string
+  default     = ""
+}
+
+variable "node_termination_handler_spot_event_name" {
+  description = "Override name of the Cloudwatch Event to handle spot termination of nodes"
+  type        = string
+  default     = ""
+}
+
 variable "node_termination_handler_iam_role" {
   description = "Override the name of the Node Termination Handler IAM Role"
   type        = string

--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -367,7 +367,7 @@ variable "node_termination_handler_permissions_boundary" {
 variable "node_termination_handler_sqs_arn" {
   description = "ARN of the SQS used in Node Termination Handler"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "node_termination_handler_release_name" {

--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -346,6 +346,12 @@ variable "ecr_pull_through_cache_rules" {
 ###############################
 # Node Termination Handler
 ###############################
+variable "node_termination_handler_enable" {
+  description = "Enable node_termination_handler creation. Only needed for self managed node groups."
+  type        = bool
+  default     = false
+}
+
 variable "node_termination_handler_iam_role" {
   description = "Override the name of the Node Termination Handler IAM Role"
   type        = string

--- a/modules/self_managed_nodes/README.md
+++ b/modules/self_managed_nodes/README.md
@@ -46,8 +46,8 @@ the type of images:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | 0.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.7 |
 
 ## Modules
 

--- a/modules/self_managed_nodes/README.md
+++ b/modules/self_managed_nodes/README.md
@@ -53,7 +53,7 @@ the type of images:
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_self_managed_group"></a> [self\_managed\_group](#module\_self\_managed\_group) | terraform-aws-modules/eks/aws//modules/self-managed-node-group | ~> 18.26.0 |
+| <a name="module_self_managed_group"></a> [self\_managed\_group](#module\_self\_managed\_group) | terraform-aws-modules/eks/aws//modules/self-managed-node-group | ~> 18.29.0 |
 
 ## Resources
 

--- a/modules/self_managed_nodes/README.md
+++ b/modules/self_managed_nodes/README.md
@@ -46,8 +46,8 @@ the type of images:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.0 |
-| <a name="provider_time"></a> [time](#provider\_time) | ~> 0.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.29.0 |
+| <a name="provider_time"></a> [time](#provider\_time) | 0.8.0 |
 
 ## Modules
 

--- a/modules/self_managed_nodes/main.tf
+++ b/modules/self_managed_nodes/main.tf
@@ -57,7 +57,7 @@ locals {
 
 module "self_managed_group" {
   source  = "terraform-aws-modules/eks/aws//modules/self-managed-node-group"
-  version = "~> 18.26.0"
+  version = "~> 18.29.0"
 
   for_each = local.self_managed_node_groups
 

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -82,7 +82,8 @@ locals {
 module "node_groups" {
   source = "./modules/eks_managed_nodes"
 
-  cluster_name = module.eks.cluster_id
+  cluster_name    = module.eks.cluster_id
+  cluster_version = module.eks.cluster_version
 
   worker_iam_role_arn = aws_iam_role.workers.arn
 

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -6,17 +6,16 @@ locals {
     launch_template_use_name_prefix = true
     launch_template_name            = var.default_group_launch_template_name
 
-    platform      = "bottlerocket"
-    ami_id        = coalesce(var.default_group_ami_id, data.aws_ami.eks_default_bottlerocket.id)
-    instance_type = var.default_group_instance_type
+    platform       = "bottlerocket"
+    ami_id         = coalesce(var.default_group_ami_id, data.aws_ami.eks_default_bottlerocket.id)
+    instance_types = var.default_group_instance_types
 
     min_size = var.default_group_min_size
     max_size = var.default_group_max_size
 
     subnet_ids = coalescelist(var.default_group_subnet_ids, var.subnet_ids)
 
-    only_critical_addons_enabled = var.only_critical_addons_enabled
-
+    enable_bootstrap_user_data = true
     # See https://github.com/bottlerocket-os/bottlerocket#settings
     bootstrap_extra_args = <<-EOT
       # The admin host container provides SSH access and runs with "superpowers".
@@ -29,13 +28,26 @@ locals {
       [settings.host-containers.control]
       enabled = true
       [settings.kubernetes.node-labels]
-      ingress = "allowed"
+      "lifecycle" = "OnDemand"
       "bottlerocket.aws/updater-interface-version" = "2.0.0"
       %{if var.only_critical_addons_enabled}
       [settings.kubernetes.node-taints]
-      CriticalAddonsOnly=true:NoSchedule
+      "CriticalAddonsOnly" = "true:NoSchedule"
       %{endif}
       EOT
+
+    labels = {
+      "lifecycle"                                  = "OnDemand"
+      "bottlerocket.aws/updater-interface-version" = "2.0.0"
+    }
+
+    taints = var.only_critical_addons_enabled ? [
+      {
+        key    = "CriticalAddonsOnly"
+        value  = "true"
+        effect = "NO_SCHEDULE"
+      }
+    ] : []
 
     # See https://github.com/bottlerocket-os/bottlerocket#default-volumes
     block_device_mappings = {
@@ -62,77 +74,26 @@ locals {
     }
   }
 
-  self_managed_node_groups = merge(
+  eks_managed_node_groups = merge(
     { default = local.default_group },
-    var.self_managed_node_groups,
+    var.eks_managed_node_groups,
   )
 }
 module "node_groups" {
-  source = "./modules/self_managed_nodes"
+  source = "./modules/eks_managed_nodes"
 
   cluster_name = module.eks.cluster_id
 
-  worker_iam_instance_profile_arn = aws_iam_instance_profile.workers.arn
+  worker_iam_role_arn = aws_iam_role.workers.arn
 
   cluster_security_group_id = module.eks.cluster_security_group_id
   worker_security_group_id  = module.eks.node_security_group_id
 
-  self_managed_node_groups         = local.self_managed_node_groups
-  self_managed_node_group_defaults = var.self_managed_node_group_defaults
-
-  node_termination_handler_sqs_arn    = module.node_termination_handler_sqs.sqs_queue_arn
-  node_termination_handler_event_name = var.node_termination_handler_event_name
+  eks_managed_node_groups         = local.eks_managed_node_groups
+  eks_managed_node_group_defaults = var.eks_managed_node_group_defaults
 
   force_imdsv2 = var.force_imdsv2
   force_irsa   = var.force_irsa
-}
-
-################################################
-# Instance Refresh supporting resources
-# See example at https://github.com/terraform-aws-modules/terraform-aws-eks/tree/v18.7.2/examples/irsa_autoscale_refresh
-################################################
-locals {
-  nth_sqs_name = coalesce(var.node_termination_handler_sqs_name, "${var.cluster_name}-nth")
-}
-
-data "aws_iam_policy_document" "node_termination_handler_sqs" {
-  statement {
-    actions   = ["sqs:SendMessage"]
-    resources = ["arn:aws:sqs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:${local.nth_sqs_name}"]
-
-    principals {
-      type = "Service"
-      identifiers = [
-        "events.amazonaws.com",
-        "sqs.amazonaws.com",
-      ]
-    }
-  }
-}
-
-module "node_termination_handler_sqs" {
-  source  = "terraform-aws-modules/sqs/aws"
-  version = "~> 3.0"
-
-  name                      = local.nth_sqs_name
-  message_retention_seconds = 300
-  policy                    = data.aws_iam_policy_document.node_termination_handler_sqs.json
-}
-
-# Handler Spot Instances termination
-resource "aws_cloudwatch_event_rule" "node_termination_handler_spot" {
-  name        = coalesce(var.node_termination_handler_spot_event_name, "${var.cluster_name}-spot-termination")
-  description = "Node termination event rule for EKS Cluster ${var.cluster_name}"
-  event_pattern = jsonencode({
-    source      = ["aws.ec2"],
-    detail-type = ["EC2 Spot Instance Interruption Warning"]
-  })
-}
-
-resource "aws_cloudwatch_event_target" "node_termination_handler_spot" {
-  target_id = coalesce(var.node_termination_handler_spot_event_name, "${var.cluster_name}-spot-termination")
-  rule      = aws_cloudwatch_event_rule.node_termination_handler_spot.name
-  arn       = module.node_termination_handler_sqs.sqs_queue_arn
 }
 
 ################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,11 +13,6 @@ output "cluster_security_group_id" {
   value       = module.eks.cluster_security_group_id
 }
 
-output "worker_iam_instance_profile_arn" {
-  description = "IAM Instance Profile ARN to use for worker nodes"
-  value       = aws_iam_instance_profile.workers.arn
-}
-
 output "worker_security_group_id" {
   description = "Security Group ID of the worker nodes"
   value       = module.eks.node_security_group_id
@@ -56,9 +51,4 @@ output "ebs_kms_key_id" {
 output "ebs_kms_key_arn" {
   description = "KMS Key ARN used for EBS encryption"
   value       = module.kms_ebs.key_arn
-}
-
-output "node_termination_handler_sqs_arn" {
-  description = "ARN of the SQS queue used to handle node termination events"
-  value       = module.node_termination_handler_sqs.sqs_queue_arn
 }

--- a/variables.tf
+++ b/variables.tf
@@ -191,10 +191,10 @@ variable "default_group_ami_id" {
   default     = ""
 }
 
-variable "default_group_instance_type" {
+variable "default_group_instance_types" {
   description = "Instance type for the default node group"
-  type        = string
-  default     = "m5a.xlarge"
+  type        = list(string)
+  default     = ["m5a.xlarge", "m5.xlarge", "m5n.xlarge", "m5zn.xlarge"]
 }
 
 variable "default_group_min_size" {
@@ -227,14 +227,14 @@ variable "only_critical_addons_enabled" {
   default     = false
 }
 
-variable "self_managed_node_groups" {
-  description = "Map of self-managed node group definitions to create"
+variable "eks_managed_node_groups" {
+  description = "Map of EKS managed node group definitions to create"
   type        = any
   default     = {}
 }
 
-variable "self_managed_node_group_defaults" {
-  description = "Map of self-managed node group default configurations"
+variable "eks_managed_node_group_defaults" {
+  description = "Map of EKS managed node group default configurations"
   type        = any
   default = {
     disk_size = 50
@@ -246,11 +246,11 @@ variable "self_managed_node_group_defaults" {
       instance_metadata_tags      = "disabled"
     }
 
-    instance_refresh = {
-      strategy = "Rolling"
-    }
     update_launch_template_default_version = true
     protect_from_scale_in                  = false
+
+    ebs_optimized     = true
+    enable_monitoring = true
 
     create_iam_role       = false
     create_security_group = false


### PR DESCRIPTION
- Change core nodes to managed
- Cleanup outputs
- Disable node termination handler by default
