### PR TITLE
Update create aws_auth configmap to false

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -62,7 +62,7 @@ variable "iam_role_additional_policies" {
 variable "create_aws_auth_configmap" {
   description = "Determines whether to create the aws-auth configmap. NOTE - this is only intended for scenarios where the configmap does not exist (i.e. - when using only self-managed node groups). Most users should use `manage_aws_auth_configmap`"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "manage_aws_auth_configmap" {


### PR DESCRIPTION
Since version 0.6.0 we have switch to using EKS managed node groups by default which automatically creates a aws_auth configmap. Having `create_aws_auth_configmap=true` causes terraform plan to fail when creating a new cluster as the configmap already exists. Instead we should use `manage_aws_auth_configmap=true` that accepts the existing configmap into terraform state thereby bringing the configmap under terraform management.