### PR TITLE
fix: tflint coalescelist throws error when both lists are empty

### DIFF
--- a/node_groups.tf
+++ b/node_groups.tf
@@ -13,8 +13,7 @@ locals {
     min_size = var.default_group_min_size
     max_size = var.default_group_max_size
 
-    # tflint-ignore: all
-    subnet_ids = coalescelist(var.default_group_subnet_ids, var.subnet_ids)
+    subnet_ids = var.subnet_ids != null ? coalescelist(var.default_group_subnet_ids, var.subnet_ids): var.default_group_subnet_ids
 
     enable_bootstrap_user_data = true
     # See https://github.com/bottlerocket-os/bottlerocket#settings

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -13,7 +13,7 @@ locals {
     min_size = var.default_group_min_size
     max_size = var.default_group_max_size
 
-    subnet_ids = var.subnet_ids != null ? coalescelist(var.default_group_subnet_ids, var.subnet_ids): var.default_group_subnet_ids
+    subnet_ids = var.subnet_ids != null ? coalescelist(var.default_group_subnet_ids, var.subnet_ids) : var.default_group_subnet_ids
 
     enable_bootstrap_user_data = true
     # See https://github.com/bottlerocket-os/bottlerocket#settings

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -13,7 +13,7 @@ locals {
     min_size = var.default_group_min_size
     max_size = var.default_group_max_size
 
-    subnet_ids = length(var.subnet_ids) == 0 && length(var.default_group_subnet_ids) == 0 ? var.default_group_subnet_ids : coalescelist(var.default_group_subnet_ids, var.subnet_ids)
+    subnet_ids = length(var.subnet_ids) == 0 && length(var.default_group_subnet_ids) == 0 ? [] : coalescelist(var.default_group_subnet_ids, var.subnet_ids)
 
     enable_bootstrap_user_data = true
     # See https://github.com/bottlerocket-os/bottlerocket#settings

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -13,6 +13,7 @@ locals {
     min_size = var.default_group_min_size
     max_size = var.default_group_max_size
 
+    # tflint-ignore: all
     subnet_ids = coalescelist(var.default_group_subnet_ids, var.subnet_ids)
 
     enable_bootstrap_user_data = true

--- a/node_groups.tf
+++ b/node_groups.tf
@@ -13,7 +13,7 @@ locals {
     min_size = var.default_group_min_size
     max_size = var.default_group_max_size
 
-    subnet_ids = var.subnet_ids != null ? coalescelist(var.default_group_subnet_ids, var.subnet_ids) : var.default_group_subnet_ids
+    subnet_ids = length(var.subnet_ids) == 0 && length(var.default_group_subnet_ids) == 0 ? var.default_group_subnet_ids : coalescelist(var.default_group_subnet_ids, var.subnet_ids)
 
     enable_bootstrap_user_data = true
     # See https://github.com/bottlerocket-os/bottlerocket#settings

--- a/policies.tf
+++ b/policies.tf
@@ -27,6 +27,7 @@ data "aws_iam_policy_document" "kms_ebs" {
   # Required for EKS
   #checkov:skip=CKV_AWS_109:The is a resource policy
   #checkov:skip=CKV_AWS_111:The is a resource policy
+  #checkov:skip=CKV_AWS_356:Ensure IAM policies limit resource access
   statement {
     sid = "Allow service-linked role use of the CMK"
     actions = [


### PR DESCRIPTION
Tflint interprets `var.subnet_ids` and `var.default_group_subnet_ids` as empty lists so when a `coalescelist` function is called on these `vars` it throws an error. A check has been added to avoid this issue.