### PR TITLE
Add block mappings to customize volume size

### DIFF
--- a/modules/karpenter/karpenter.tf
+++ b/modules/karpenter/karpenter.tf
@@ -165,7 +165,6 @@ resource "kubernetes_manifest" "karpenter_node_template" {
           }
         },
       ]
-      # each.value.karpenter_block_device_mappings
 
       tags = each.value.karpenter_nodetemplate_tag_map
     }

--- a/modules/karpenter/karpenter.tf
+++ b/modules/karpenter/karpenter.tf
@@ -147,7 +147,25 @@ resource "kubernetes_manifest" "karpenter_node_template" {
       subnetSelector        = each.value.karpenter_subnet_selector_map
       securityGroupSelector = each.value.karpenter_security_group_selector_map
       amiFamily             = each.value.karpenter_ami_family
-      blockDeviceMappings   = each.value.karpenter_block_device_mappings
+      blockDeviceMappings = [
+        {
+          deviceName = "/dev/xvda"
+          ebs = {
+            volumeSize = each.value.karpenter_root_volume_size
+            volumeType = "gp3"
+            encrypted  = true
+          }
+        },
+        {
+          deviceName = "/dev/xvdb"
+          ebs = {
+            volumeSize = each.value.karpenter_ephemeral_volume_size
+            volumeType = "gp3"
+            encrypted  = true
+          }
+        },
+      ]
+      # each.value.karpenter_block_device_mappings
 
       tags = each.value.karpenter_nodetemplate_tag_map
     }

--- a/modules/karpenter/karpenter.tf
+++ b/modules/karpenter/karpenter.tf
@@ -147,6 +147,7 @@ resource "kubernetes_manifest" "karpenter_node_template" {
       subnetSelector        = each.value.karpenter_subnet_selector_map
       securityGroupSelector = each.value.karpenter_security_group_selector_map
       amiFamily             = each.value.karpenter_ami_family
+      blockDeviceMappings   = each.value.karpenter_block_device_mappings
 
       tags = each.value.karpenter_nodetemplate_tag_map
     }

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -64,7 +64,8 @@ variable "karpenter_nodetemplates" {
     karpenter_security_group_selector_map = map(string)
     karpenter_nodetemplate_tag_map        = map(string)
     karpenter_ami_family                  = string
-    karpenter_block_device_mappings       = list(map(any))
+    karpenter_root_volume_size            = number
+    karpenter_ephemeral_volume_size       = number
   }))
   default = []
   ## sample below

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -64,7 +64,7 @@ variable "karpenter_nodetemplates" {
     karpenter_security_group_selector_map = map(string)
     karpenter_nodetemplate_tag_map        = map(string)
     karpenter_ami_family                  = string
-    karpenter_block_device_mappings       = list(map(string))
+    karpenter_block_device_mappings       = list(map(any))
   }))
   default = []
   ## sample below

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -75,8 +75,8 @@ variable "karpenter_nodetemplates" {
   #   karpenter_security_group_selector_map = {}
   #   karpenter_nodetemplate_tag_map        = {}
   #   karpenter_ami_family                  = "Bottlerocket"
-  #   karpenter_root_volume_size            = 5G
-  #   karpenter_ephemeral_volume_size       = 50G
+  #   karpenter_root_volume_size            = "5Gi"
+  #   karpenter_ephemeral_volume_size       = "50Gi"
   # }]
 }
 

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -64,6 +64,7 @@ variable "karpenter_nodetemplates" {
     karpenter_security_group_selector_map = map(string)
     karpenter_nodetemplate_tag_map        = map(string)
     karpenter_ami_family                  = string
+    karpenter_block_device_mappings       = list(map(string))
   }))
   default = []
   ## sample below
@@ -73,6 +74,7 @@ variable "karpenter_nodetemplates" {
   #   karpenter_security_group_selector_map = {}
   #   karpenter_nodetemplate_tag_map        = {}
   #   karpenter_ami_family                  = "Bottlerocket"
+  #   karpenter_block_device_mappings       = []
   # }]
 }
 

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -64,8 +64,8 @@ variable "karpenter_nodetemplates" {
     karpenter_security_group_selector_map = map(string)
     karpenter_nodetemplate_tag_map        = map(string)
     karpenter_ami_family                  = string
-    karpenter_root_volume_size            = number
-    karpenter_ephemeral_volume_size       = number
+    karpenter_root_volume_size            = string
+    karpenter_ephemeral_volume_size       = string
   }))
   default = []
   ## sample below
@@ -75,8 +75,8 @@ variable "karpenter_nodetemplates" {
   #   karpenter_security_group_selector_map = {}
   #   karpenter_nodetemplate_tag_map        = {}
   #   karpenter_ami_family                  = "Bottlerocket"
-  #   karpenter_root_volume_size            = 5
-  #   karpenter_ephemeral_volume_size       = 50
+  #   karpenter_root_volume_size            = 5G
+  #   karpenter_ephemeral_volume_size       = 50G
   # }]
 }
 

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -75,7 +75,8 @@ variable "karpenter_nodetemplates" {
   #   karpenter_security_group_selector_map = {}
   #   karpenter_nodetemplate_tag_map        = {}
   #   karpenter_ami_family                  = "Bottlerocket"
-  #   karpenter_block_device_mappings       = []
+  #   karpenter_root_volume_size            = 5
+  #   karpenter_ephemeral_volume_size       = 50
   # }]
 }
 


### PR DESCRIPTION
Current default for bottlerocket is 
https://karpenter.sh/v0.27/concepts/node-templates/#bottlerocket
```yaml
apiVersion: karpenter.k8s.aws/v1alpha1
kind: AWSNodeTemplate
spec:
  blockDeviceMappings:
    # Root device
    - deviceName: /dev/xvda
      ebs:
        volumeSize: 4Gi
        volumeType: gp3
        encrypted: true
    # Data device: Container resources such as images and logs
    - deviceName: /dev/xvdb
      ebs:
        volumeSize: 20Gi
        volumeType: gp3
        encrypted: true

```
Which is insufficient for some workloads