### PR TITLE
Add flag to disable bottlerocket update operator

### DIFF
--- a/fargate_profile.tf
+++ b/fargate_profile.tf
@@ -1,6 +1,5 @@
 locals {
-
-  essentials_namespaces  = ["opentelemetry-operator-system", "cert-manager", "brupop-bottlerocket-aws"] # to add more if the essentials module deploys in any new namespaces
+  essentials_namespaces  = ["opentelemetry-operator-system", "cert-manager"] # to add more if the essentials module deploys in any new namespaces
   kube_system_namespaces = ["kube-system"]
 
   fargate_namespaces = concat(local.essentials_namespaces, local.kube_system_namespaces)
@@ -33,7 +32,6 @@ locals {
         subnet_ids = [subnet]
       }
     },
-
   )
 
   fargate_profiles = merge(
@@ -41,6 +39,7 @@ locals {
     var.fargate_profiles,
   )
 }
+
 module "fargate_profiles" {
   source = "./modules/fargate_profile"
 
@@ -56,9 +55,7 @@ module "fargate_profiles" {
 }
 
 resource "kubernetes_manifest" "fargate_node_security_group_policy" {
-
   count = var.fargate_cluster && var.create_node_security_group ? 1 : 0
-
   manifest = {
     apiVersion = "vpcresources.k8s.aws/v1beta1"
     kind       = "SecurityGroupPolicy"
@@ -81,8 +78,7 @@ resource "aws_iam_policy" "fargate_logging" {
   name        = "fargate_logging_cloudwatch_default"
   path        = "/"
   description = "AWS recommended cloudwatch perms policy"
-
-  policy = data.aws_iam_policy_document.fargate_logging.json
+  policy      = data.aws_iam_policy_document.fargate_logging.json
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards

--- a/modules/essentials/README.md
+++ b/modules/essentials/README.md
@@ -123,6 +123,7 @@ module "eks_essentials" {
 | <a name="input_brupop_chart_name"></a> [brupop\_chart\_name](#input\_brupop\_chart\_name) | Chart name for brupop | `string` | `"bottlerocket-brupop"` | no |
 | <a name="input_brupop_chart_repository"></a> [brupop\_chart\_repository](#input\_brupop\_chart\_repository) | Chart repository for brupop | `string` | `"oci://public.ecr.aws/sphmedia/helm/"` | no |
 | <a name="input_brupop_chart_version"></a> [brupop\_chart\_version](#input\_brupop\_chart\_version) | Chart version for brupop | `string` | `"1.0.3"` | no |
+| <a name="input_brupop_enabled"></a> [brupop\_enabled](#input\_brupop\_enabled) | Enable Bottle Rocket Update Operator | `bool` | `true` | no |
 | <a name="input_brupop_image"></a> [brupop\_image](#input\_brupop\_image) | Docker image for brupop | `string` | `"public.ecr.aws/bottlerocket/bottlerocket-update-operator"` | no |
 | <a name="input_brupop_namespace"></a> [brupop\_namespace](#input\_brupop\_namespace) | Namespace for all resources under bottlerocket update operator | `string` | `"brupop-bottlerocket-aws"` | no |
 | <a name="input_brupop_release_name"></a> [brupop\_release\_name](#input\_brupop\_release\_name) | Release name for brupop | `string` | `"bottlerocket-brupop"` | no |

--- a/modules/essentials/brupop.tf
+++ b/modules/essentials/brupop.tf
@@ -1,4 +1,6 @@
 resource "helm_release" "brupop" {
+  count = var.brupop_enabled ? 1 : 0
+
   name       = var.brupop_release_name
   chart      = var.brupop_chart_name
   repository = var.brupop_chart_repository

--- a/modules/essentials/brupop.tf
+++ b/modules/essentials/brupop.tf
@@ -30,3 +30,9 @@ locals {
     brupop_tag       = var.brupop_tag
   }
 }
+
+# Added option to disable bottlerocket update operator
+moved {
+  from = helm_release.brupop
+  to   = helm_release.brupop[0]
+}

--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -526,6 +526,11 @@ variable "node_termination_service_account" {
 ###############################
 # Bottle Rocket Update Operator
 ###############################
+variable "brupop_enabled" {
+  description = "Enable Bottle Rocket Update Operator"
+  type        = bool
+  default     = true
+}
 
 variable "brupop_namespace" {
   description = "Namespace for all resources under bottlerocket update operator"


### PR DESCRIPTION
Bottlerocket update operator starts a controller deployment on one node, an agent daemon set on every Bottlerocket node, and an Update Operator API Server deployment. All components together collaborate to drive each Bottlerocket node through an update when updates are available.

Since the agent is a daemon set, it does not make sense to create fargate-profile for that. Daemonsets aren't supported on Fargate. 

Added option to disable brupop for fargate only clusters.