### PR TITLE
Add condition and config values for enabling POD ENI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,6 @@ permissions:
   security-events: write
 jobs:
   ci:
-    uses: SPHTech-Platform/reusable-workflows/.github/workflows/terraform.yaml@main
+    uses: SPHTech-Platform/reusable-workflows/.github/workflows/terraform.yaml@v2
     with:
       upload_sarif: true

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.17.0"
+  version = "0.22.1"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/fargate_profile.tf
+++ b/fargate_profile.tf
@@ -60,7 +60,7 @@ resource "kubernetes_manifest" "fargate_node_security_group_policy" {
     apiVersion = "vpcresources.k8s.aws/v1beta1"
     kind       = "SecurityGroupPolicy"
     metadata = {
-      name      = "fargate-node-default-namespace-sg"
+      name      = "fargate-node-kube-system-namespace-sg"
       namespace = "kube-system"
     }
     spec = {

--- a/main.tf
+++ b/main.tf
@@ -73,7 +73,7 @@ module "eks" {
       service_account_role_arn = module.vpc_cni_irsa_role.iam_role_arn
       configuration_values = jsonencode({
         env = {
-          ENABLE_POD_ENI = true
+          ENABLE_POD_ENI = "true"
         }
       })
       } : {

--- a/main.tf
+++ b/main.tf
@@ -74,7 +74,8 @@ module "eks" {
       configuration_values = jsonencode({
         env = {
           # Reference doc: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-deployment
-          ENABLE_POD_ENI = "true"
+          ENABLE_POD_ENI          = "true"
+          DISABLE_TCP_EARLY_DEMUX = "true"
         }
       })
       } : {

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,16 @@ module "eks" {
       most_recent = true
       reserve     = true
     }
-    vpc-cni = {
+    vpc-cni = var.fargate_cluster ? {
+      most_recent              = true
+      reserve                  = true
+      service_account_role_arn = module.vpc_cni_irsa_role.iam_role_arn
+      configuration_values = jsonencode({
+        env = {
+          ENABLE_POD_ENI = true
+        }
+      })
+      } : {
       most_recent              = true
       reserve                  = true
       service_account_role_arn = module.vpc_cni_irsa_role.iam_role_arn

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,7 @@ module "eks" {
       service_account_role_arn = module.vpc_cni_irsa_role.iam_role_arn
       configuration_values = jsonencode({
         env = {
+          # Reference doc: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-deployment
           ENABLE_POD_ENI = "true"
         }
       })


### PR DESCRIPTION
https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-deployment 

Requires ENABLE_POD_ENI to be set to true for SecurityGroupPolicy to be added to pods on managed nodes 