### PR TITLE
Add rule to node security group

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -51,9 +51,18 @@ module "eks" {
     }
   }, var.cluster_security_group_additional_rules)
 
-  node_security_group_name                     = coalesce(var.worker_security_group_name, join("_", [var.cluster_name, "worker"]))
-  node_security_group_description              = "EKS Cluster ${var.cluster_name} Nodes"
-  node_security_group_additional_rules         = var.node_security_group_additional_rules
+  node_security_group_name        = coalesce(var.worker_security_group_name, join("_", [var.cluster_name, "worker"]))
+  node_security_group_description = "EKS Cluster ${var.cluster_name} Nodes"
+  node_security_group_additional_rules = merge({
+    ingress_from_cluster_security_group = {
+      description                   = "Cluster API to node kubelets"
+      protocol                      = "tcp"
+      from_port                     = 10260
+      to_port                       = 10260
+      type                          = "ingress"
+      source_cluster_security_group = true
+    }
+  }, var.node_security_group_additional_rules)
   node_security_group_enable_recommended_rules = var.node_security_group_enable_recommended_rules
 
   create_kms_key = false # Created in kms.tf


### PR DESCRIPTION
Add ingress rule to `node_security_group` due to recent update in #69 

**Reference**
https://cert-manager.io/docs/installation/compatibility/