### PR TITLE
Add initEnv instead of Env to fix pod constantly restart issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,8 @@ module "eks" {
       configuration_values = jsonencode({
         env = {
           # Reference doc: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-deployment
-          ENABLE_POD_ENI = "true"
+          ENABLE_POD_ENI                    = "true"
+          POD_SECURITY_GROUP_ENFORCING_MODE = "standard"
         }
         init = {
           env = {

--- a/main.tf
+++ b/main.tf
@@ -87,9 +87,7 @@ module "eks" {
         }
         init = {
           env = {
-            initEnv = {
-              DISABLE_TCP_EARLY_DEMUX = "true"
-            }
+            DISABLE_TCP_EARLY_DEMUX = "true"
           }
         }
       })

--- a/main.tf
+++ b/main.tf
@@ -85,8 +85,12 @@ module "eks" {
           # Reference doc: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-deployment
           ENABLE_POD_ENI = "true"
         }
-        InitEnv = {
-          DISABLE_TCP_EARLY_DEMUX = "true"
+        init = {
+          env = {
+            initEnv = {
+              DISABLE_TCP_EARLY_DEMUX = "true"
+            }
+          }
         }
       })
       } : {

--- a/main.tf
+++ b/main.tf
@@ -83,7 +83,9 @@ module "eks" {
       configuration_values = jsonencode({
         env = {
           # Reference doc: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-deployment
-          ENABLE_POD_ENI          = "true"
+          ENABLE_POD_ENI = "true"
+        }
+        InitEnv = {
           DISABLE_TCP_EARLY_DEMUX = "true"
         }
       })


### PR DESCRIPTION
`aws eks describe-addon-configuration --addon-name vpc-cni --addon-version v1.13.2-eksbuild.1`

```
{
  "$ref": "#/definitions/VpcCni",
  "$schema": "http://json-schema.org/draft-06/schema#",
  "definitions": {
    "Affinity": {
      "type": [
        "object",
        "null"
      ]
    },
    "EniConfig": {
      "additionalProperties": false,
      "properties": {
        "create": {
          "type": "boolean"
        },
        "region": {
          "type": "string"
        },
        "subnets": {
          "additionalProperties": {
            "additionalProperties": false,
            "properties": {
              "id": {
                "type": "string"
              },
              "securityGroups": {
                "items": {
                  "type": "string"
                },
                "type": "array"
              }
            },
            "required": [
              "id"
            ],
            "type": "object"
          },
          "minProperties": 1,
          "type": "object"
        }
      },
      "required": [
        "create",
        "region",
        "subnets"
      ],
      "type": "object"
    },
    "Env": {
      "additionalProperties": false,
      "properties": {
        "ADDITIONAL_ENI_TAGS": {
          "type": "string"
        },
        "ANNOTATE_POD_IP": {
          "format": "boolean",
          "type": "string"
        },
        "AWS_EC2_ENDPOINT": {
          "type": "string"
        },
        "AWS_EXTERNAL_SERVICE_CIDRS": {
          "type": "string"
        },
        "AWS_MANAGE_ENIS_NON_SCHEDULABLE": {
          "format": "boolean",
          "type": "string"
        },
        "AWS_VPC_CNI_NODE_PORT_SUPPORT": {
          "format": "boolean",
          "type": "string"
        },
        "AWS_VPC_ENI_MTU": {
          "format": "integer",
          "type": "string"
        },
        "AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG": {
          "format": "boolean",
          "type": "string"
        },
        "AWS_VPC_K8S_CNI_EXCLUDE_SNAT_CIDRS": {
          "type": "string"
        },
        "AWS_VPC_K8S_CNI_EXTERNALSNAT": {
          "format": "boolean",
          "type": "string"
        },
        "AWS_VPC_K8S_CNI_LOGLEVEL": {
          "type": "string"
        },
        "AWS_VPC_K8S_CNI_LOG_FILE": {
          "type": "string"
        },
        "AWS_VPC_K8S_CNI_RANDOMIZESNAT": {
          "type": "string"
        },
        "AWS_VPC_K8S_CNI_VETHPREFIX": {
          "type": "string"
        },
        "AWS_VPC_K8S_PLUGIN_LOG_FILE": {
          "type": "string"
        },
        "AWS_VPC_K8S_PLUGIN_LOG_LEVEL": {
          "type": "string"
        },
        "CLUSTER_ENDPOINT": {
          "type": "string"
        },
        "DISABLE_INTROSPECTION": {
          "format": "boolean",
          "type": "string"
        },
        "DISABLE_LEAKED_ENI_CLEANUP": {
          "format": "boolean",
          "type": "string"
        },
        "DISABLE_METRICS": {
          "format": "boolean",
          "type": "string"
        },
        "DISABLE_NETWORK_RESOURCE_PROVISIONING": {
          "format": "boolean",
          "type": "string"
        },
        "ENABLE_BANDWIDTH_PLUGIN": {
          "format": "boolean",
          "type": "string"
        },
        "ENABLE_POD_ENI": {
          "format": "boolean",
          "type": "string"
        },
        "ENABLE_PREFIX_DELEGATION": {
          "format": "boolean",
          "type": "string"
        },
        "ENABLE_V6_EGRESS": {
          "format": "boolean",
          "type": "string"
        },
        "ENI_CONFIG_ANNOTATION_DEF": {
          "type": "string"
        },
        "ENI_CONFIG_LABEL_DEF": {
          "type": "string"
        },
        "INTROSPECTION_BIND_ADDRESS": {
          "type": "string"
        },
        "MAX_ENI": {
          "format": "integer",
          "type": "string"
        },
        "MINIMUM_IP_TARGET": {
          "format": "integer",
          "type": "string"
        },
        "POD_SECURITY_GROUP_ENFORCING_MODE": {
          "type": "string"
        },
        "WARM_ENI_TARGET": {
          "format": "integer",
          "type": "string"
        },
        "WARM_IP_TARGET": {
          "format": "integer",
          "type": "string"
        },
        "WARM_PREFIX_TARGET": {
          "format": "integer",
          "type": "string"
        }
      },
      "title": "Env",
      "type": "object"
    },
    "Init": {
      "additionalProperties": false,
      "properties": {
        "env": {
          "$ref": "#/definitions/InitEnv"
        }
      },
      "title": "Init",
      "type": "object"
    },
    "InitEnv": {
      "additionalProperties": false,
      "properties": {
        "DISABLE_TCP_EARLY_DEMUX": {
          "format": "boolean",
          "type": "string"
        },
        "ENABLE_V6_EGRESS": {
          "format": "boolean",
          "type": "string"
        }
      },
      "title": "InitEnv",
      "type": "object"
    },
    "Limits": {
      "additionalProperties": false,
      "properties": {
        "cpu": {
          "type": "string"
        },
        "memory": {
          "type": "string"
        }
      },
      "title": "Limits",
      "type": "object"
    },
    "Resources": {
      "additionalProperties": false,
      "properties": {
        "limits": {
          "$ref": "#/definitions/Limits"
        },
        "requests": {
          "$ref": "#/definitions/Limits"
        }
      },
      "title": "Resources",
      "type": "object"
    },
    "Tolerations": {
      "additionalProperties": false,
      "items": {
        "type": "object"
      },
      "type": "array"
    },
    "VpcCni": {
      "additionalProperties": false,
      "properties": {
        "affinity": {
          "$ref": "#/definitions/Affinity"
        },
        "eniConfig": {
          "$ref": "#/definitions/EniConfig"
        },
        "env": {
          "$ref": "#/definitions/Env"
        },
        "init": {
          "$ref": "#/definitions/Init"
        },
        "livenessProbeTimeoutSeconds": {
          "type": "integer"
        },
        "readinessProbeTimeoutSeconds": {
          "type": "integer"
        },
        "resources": {
          "$ref": "#/definitions/Resources"
        },
        "tolerations": {
          "$ref": "#/definitions/Tolerations"
        }
      },
      "title": "VpcCni",
      "type": "object"
    }
  },
  "description": "vpc-cni"
}
```

Its not too clear but it is actually in the initEnv key instead of Env key