### PR TITLE
Fix empty Fargate Stream Log Prefix

### DIFF
--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -10,7 +10,7 @@ locals {
         Match   kube.*
         region ${data.aws_region.current.name}
         log_group_name ${local.cwlog_group}
-        %{if local.cwlog_stream_prefix != "" }log_stream_prefix ${local.cwlog_stream_prefix}%{endif}
+        %{if local.cwlog_stream_prefix != ""}log_stream_prefix ${local.cwlog_stream_prefix}%{endif}
         log_stream_template $kubernetes['pod_name'].$kubernetes['container_name']
     EOF
     filters_conf = <<-EOF

--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -10,7 +10,7 @@ locals {
         Match   kube.*
         region ${data.aws_region.current.name}
         log_group_name ${local.cwlog_group}
-        log_stream_prefix ${local.cwlog_stream_prefix}
+        %{if local.cwlog_stream_prefix != "" }log_stream_prefix ${local.cwlog_stream_prefix}%{endif}
         log_stream_template $kubernetes['pod_name'].$kubernetes['container_name']
     EOF
     filters_conf = <<-EOF


### PR DESCRIPTION
` Error: Failed to update Config Map: admission webhook "0500-amazon-eks-fargate-configmaps-admission.amazonaws.com" denied the request: Line is an invalid key/value pair, or a wrong directive. Line: log_stream_prefix `
