### PR TITLE
Revamp Fargate Logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ module "karpenter" {
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_ebs_csi_irsa_role"></a> [ebs\_csi\_irsa\_role](#module\_ebs\_csi\_irsa\_role) | terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks | ~> 5.11.2 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.15.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | ~> 19.16.0 |
 | <a name="module_fargate_profiles"></a> [fargate\_profiles](#module\_fargate\_profiles) | ./modules/fargate_profile | n/a |
 | <a name="module_kms_ebs"></a> [kms\_ebs](#module\_kms\_ebs) | SPHTech-Platform/kms/aws | ~> 0.1.0 |
 | <a name="module_kms_secret"></a> [kms\_secret](#module\_kms\_secret) | SPHTech-Platform/kms/aws | ~> 0.1.0 |
@@ -224,7 +224,6 @@ module "karpenter" {
 
 | Name | Type |
 |------|------|
-| [aws_iam_policy.fargate_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.workers](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy.ebs_csi_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
@@ -238,7 +237,6 @@ module "karpenter" {
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.ec2_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.eks_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.fargate_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_csi_ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.kms_ebs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |

--- a/fargate_profile.tf
+++ b/fargate_profile.tf
@@ -7,8 +7,8 @@ locals {
   default_fargate_profiles = merge(
     {
       essentials = {
-        iam_role_name                = "fargate_profile_essentials"
-        subnet_ids                   = var.subnet_ids
+        iam_role_name = "fargate_profile_essentials"
+        subnet_ids    = var.subnet_ids
         selectors = [
           for ns_value in local.essentials_namespaces : {
             namespace = ns_value
@@ -18,7 +18,7 @@ locals {
     },
     { for subnet in var.subnet_ids :
       "kube-system-${substr(data.aws_subnet.subnets[subnet].availability_zone, -2, -1)}" => {
-        iam_role_name                = "fargate_profile_${substr(data.aws_subnet.subnets[subnet].availability_zone, -2, -1)}"
+        iam_role_name = "fargate_profile_${substr(data.aws_subnet.subnets[subnet].availability_zone, -2, -1)}"
         selectors = [
           { namespace = "kube-system" }
         ]

--- a/fargate_profile.tf
+++ b/fargate_profile.tf
@@ -4,15 +4,10 @@ locals {
 
   fargate_namespaces = concat(local.essentials_namespaces, local.kube_system_namespaces)
 
-  fargate_iam_role_additional_policies = var.fargate_cluster ? {
-    additional = aws_iam_policy.fargate_logging[0].arn
-  } : {}
-
   default_fargate_profiles = merge(
     {
       essentials = {
         iam_role_name                = "fargate_profile_essentials"
-        iam_role_additional_policies = local.fargate_iam_role_additional_policies
         subnet_ids                   = var.subnet_ids
         selectors = [
           for ns_value in local.essentials_namespaces : {
@@ -24,7 +19,6 @@ locals {
     { for subnet in var.subnet_ids :
       "kube-system-${substr(data.aws_subnet.subnets[subnet].availability_zone, -2, -1)}" => {
         iam_role_name                = "fargate_profile_${substr(data.aws_subnet.subnets[subnet].availability_zone, -2, -1)}"
-        iam_role_additional_policies = local.fargate_iam_role_additional_policies
         selectors = [
           { namespace = "kube-system" }
         ]
@@ -73,37 +67,4 @@ resource "kubernetes_manifest" "fargate_node_security_group_policy" {
       }
     }
   }
-}
-
-resource "aws_iam_policy" "fargate_logging" {
-  count = var.fargate_cluster ? 1 : 0
-
-  name        = var.fargate_logging_policy
-  path        = "/"
-  description = "AWS recommended cloudwatch perms policy"
-  policy      = data.aws_iam_policy_document.fargate_logging.json
-}
-
-#tfsec:ignore:aws-iam-no-policy-wildcards
-data "aws_iam_policy_document" "fargate_logging" {
-  #checkov:skip=CKV_AWS_111:Restricted to Cloudwatch Actions only
-  #checkov:skip=CKV_AWS_356: Only logs actions
-  statement {
-    sid       = ""
-    effect    = "Allow"
-    resources = ["*"]
-
-    actions = [
-      "logs:CreateLogStream",
-      "logs:CreateLogGroup",
-      "logs:DescribeLogStreams",
-      "logs:PutLogEvents",
-      "logs:PutRetentionPolicy", #for overriding alr created log groups
-    ]
-  }
-}
-
-moved {
-  from = aws_iam_policy.fargate_logging
-  to   = aws_iam_policy.fargate_logging[0]
 }

--- a/main.tf
+++ b/main.tf
@@ -15,7 +15,7 @@ locals {
 #tfsec:ignore:aws-eks-enable-control-plane-logging
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.15.0"
+  version = "~> 19.16.0"
 
   cluster_name    = var.cluster_name
   cluster_version = var.cluster_version

--- a/modules/essentials/templates/fluent_bit.yaml
+++ b/modules/essentials/templates/fluent_bit.yaml
@@ -110,7 +110,7 @@ config:
         Match kube.*
         region ap-southeast-1
         log_group_name ${log_group_name}
-        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])
+        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
         auto_create_group false
 
 #  extraFiles: {}

--- a/modules/essentials/templates/fluent_bit.yaml
+++ b/modules/essentials/templates/fluent_bit.yaml
@@ -110,8 +110,7 @@ config:
         Match kube.*
         region ap-southeast-1
         log_group_name ${log_group_name}
-        log_stream_prefix fluentbit-
-        log_stream_template $kubernetes['pod_name'].$kubernetes['container_name']
+        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])
         auto_create_group false
 
 #  extraFiles: {}

--- a/modules/essentials/templates/fluent_bit.yaml
+++ b/modules/essentials/templates/fluent_bit.yaml
@@ -110,7 +110,8 @@ config:
         Match kube.*
         region ap-southeast-1
         log_group_name ${log_group_name}
-        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
+        log_stream_template $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
+        log_stream_prefix fluentbit-
         auto_create_group false
 
 #  extraFiles: {}

--- a/modules/fargate_profile/README.md
+++ b/modules/fargate_profile/README.md
@@ -73,16 +73,18 @@ module "fargate_profile" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | terraform-aws-modules/eks/aws//modules/fargate-profile | ~> 19.15.0 |
+| <a name="module_fargate_profile"></a> [fargate\_profile](#module\_fargate\_profile) | terraform-aws-modules/eks/aws//modules/fargate-profile | ~> 19.16.0 |
 
 ## Resources
 
 | Name | Type |
 |------|------|
 | [aws_cloudwatch_log_group.fargate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
+| [aws_iam_policy.fargate_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [kubernetes_config_map_v1.aws_logging](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map_v1) | resource |
 | [kubernetes_manifest.sg](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
 | [kubernetes_namespace_v1.aws_observability](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace_v1) | resource |
+| [aws_iam_policy_document.fargate_logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 
 ## Inputs
@@ -94,9 +96,10 @@ module "fargate_profile" {
 | <a name="input_create_aws_observability_ns"></a> [create\_aws\_observability\_ns](#input\_create\_aws\_observability\_ns) | value to determine if aws-observability namespace is created | `bool` | `true` | no |
 | <a name="input_create_fargate_log_group"></a> [create\_fargate\_log\_group](#input\_create\_fargate\_log\_group) | Create Fargate Cloudwatch Log group | `bool` | `true` | no |
 | <a name="input_create_fargate_logger_configmap"></a> [create\_fargate\_logger\_configmap](#input\_create\_fargate\_logger\_configmap) | value to determine if create\_fargate\_logger\_configmap is created | `bool` | `true` | no |
+| <a name="input_create_fargate_logging_policy"></a> [create\_fargate\_logging\_policy](#input\_create\_fargate\_logging\_policy) | Create and attach fargate logging policy | `bool` | `true` | no |
 | <a name="input_eks_worker_security_group_id"></a> [eks\_worker\_security\_group\_id](#input\_eks\_worker\_security\_group\_id) | Security Group ID of the worker nodes | `string` | `""` | no |
 | <a name="input_fargate_log_group_retention_days"></a> [fargate\_log\_group\_retention\_days](#input\_fargate\_log\_group\_retention\_days) | Specifies the number of days you want to retain log events in the specified log group. Possible values are: 1, 3, 5, 7, 14, 30, 60, 90, 120, 150, 180, 365, 400, 545, 731, 1096, 1827, 2192, 2557, 2922, 3288, 3653, and 0. If you select 0, the events in the log group are always retained and never expire. | `number` | `90` | no |
-| <a name="input_fargate_log_stream_prefix"></a> [fargate\_log\_stream\_prefix](#input\_fargate\_log\_stream\_prefix) | Log stream prefix | `string` | `""` | no |
+| <a name="input_fargate_logging_policy_suffix"></a> [fargate\_logging\_policy\_suffix](#input\_fargate\_logging\_policy\_suffix) | Name of Fargate Logging Policy | `string` | `"fargate-logging"` | no |
 | <a name="input_fargate_namespaces_for_security_group"></a> [fargate\_namespaces\_for\_security\_group](#input\_fargate\_namespaces\_for\_security\_group) | List of fargate namespaces to craete SecurityGroupPolicy for talking to managed nodes | `list(string)` | `[]` | no |
 | <a name="input_fargate_profile_defaults"></a> [fargate\_profile\_defaults](#input\_fargate\_profile\_defaults) | Map of Fargate Profile default configurations | `any` | `{}` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | Map of maps of `fargate_profiles` to create | `any` | `{}` | no |

--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -1,15 +1,18 @@
 locals {
   cwlog_group = "/aws/eks/${var.cluster_name}/fargate-fluentbit-logs"
 
-  # https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit
+  # https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch
   default_config = {
+    # https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#log-stream-and-group-name-templating-using-record_accessor-syntax
+    # log_stream_prefix is fallback
     output_conf  = <<-EOF
     [OUTPUT]
         Name cloudwatch_logs
         Match   kube.*
         region ${data.aws_region.current.name}
         log_group_name ${local.cwlog_group}
-        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
+        log_stream_template $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
+        log_stream_prefix fluentbit-
         auto_create_group false
     EOF
     filters_conf = <<-EOF

--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -1,17 +1,15 @@
 locals {
   cwlog_group = "/aws/eks/${var.cluster_name}/fargate-fluentbit-logs"
 
-  # https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch
+  # https://docs.fluentbit.io/manual/v/1.5/pipeline/outputs/cloudwatch
   default_config = {
-    # https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#log-stream-and-group-name-templating-using-record_accessor-syntax
-    # log_stream_prefix is fallback
+    # log_stream_template does not exist on 1.5
     output_conf  = <<-EOF
     [OUTPUT]
         Name cloudwatch_logs
         Match   kube.*
         region ${data.aws_region.current.name}
         log_group_name ${local.cwlog_group}
-        log_stream_template $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
         log_stream_prefix fluentbit-
         auto_create_group false
     EOF

--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -110,7 +110,7 @@ data "aws_iam_policy_document" "fargate_logging" {
       "logs:CreateLogGroup",
       "logs:DescribeLogStreams",
       "logs:PutLogEvents",
-      "logs:PutRetentionPolicy",  # for overriding alr created log groups
+      "logs:PutRetentionPolicy", # for overriding alr created log groups
     ]
   }
 }

--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -9,7 +9,7 @@ locals {
         Match   kube.*
         region ${data.aws_region.current.name}
         log_group_name ${local.cwlog_group}
-        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])
+        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
         auto_create_group false
     EOF
     filters_conf = <<-EOF

--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -9,7 +9,7 @@ locals {
         Match   kube.*
         region ${data.aws_region.current.name}
         log_group_name ${local.cwlog_group}
-        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])
+        log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])
         log_retention_days ${var.fargate_log_group_retention_days}
         auto_create_group false
     EOF

--- a/modules/fargate_profile/fargate_logger.tf
+++ b/modules/fargate_profile/fargate_logger.tf
@@ -5,12 +5,11 @@ locals {
   default_config = {
     output_conf  = <<-EOF
     [OUTPUT]
-        Name cloudwatch
+        Name cloudwatch_logs
         Match   kube.*
         region ${data.aws_region.current.name}
         log_group_name ${local.cwlog_group}
         log_stream_name $(kubernetes['namespace_name'])/$(kubernetes['container_name'])/$(kubernetes['pod_name'])
-        log_retention_days ${var.fargate_log_group_retention_days}
         auto_create_group false
     EOF
     filters_conf = <<-EOF

--- a/modules/fargate_profile/main.tf
+++ b/modules/fargate_profile/main.tf
@@ -18,12 +18,12 @@ module "fargate_profile" {
   iam_role_description          = lookup(each.value, "iam_role_description", lookup(var.fargate_profile_defaults, "iam_role_description", null))
   iam_role_permissions_boundary = lookup(each.value, "iam_role_permissions_boundary", lookup(var.fargate_profile_defaults, "iam_role_permissions_boundary", null))
   iam_role_attach_cni_policy    = lookup(each.value, "iam_role_attach_cni_policy", lookup(var.fargate_profile_defaults, "iam_role_attach_cni_policy", true))
-  iam_role_additional_policies  = merge(
+  iam_role_additional_policies = merge(
     lookup(each.value, "iam_role_additional_policies", lookup(var.fargate_profile_defaults, "iam_role_additional_policies", {})),
     var.create_fargate_logging_policy ? { fargate_logging = aws_iam_policy.fargate_logging[0].arn } : {},
   )
-  iam_role_tags                 = lookup(each.value, "iam_role_tags", {})
-  tags                          = merge(var.tags, lookup(each.value, "tags", {}))
+  iam_role_tags = lookup(each.value, "iam_role_tags", {})
+  tags          = merge(var.tags, lookup(each.value, "tags", {}))
 }
 
 ## Only used when needed for testing pods running in a namespace which requires access to the managed nodes

--- a/modules/fargate_profile/main.tf
+++ b/modules/fargate_profile/main.tf
@@ -1,6 +1,6 @@
 module "fargate_profile" {
   source  = "terraform-aws-modules/eks/aws//modules/fargate-profile"
-  version = "~> 19.15.0"
+  version = "~> 19.16.0"
 
   for_each = var.fargate_profiles
 
@@ -18,7 +18,10 @@ module "fargate_profile" {
   iam_role_description          = lookup(each.value, "iam_role_description", lookup(var.fargate_profile_defaults, "iam_role_description", null))
   iam_role_permissions_boundary = lookup(each.value, "iam_role_permissions_boundary", lookup(var.fargate_profile_defaults, "iam_role_permissions_boundary", null))
   iam_role_attach_cni_policy    = lookup(each.value, "iam_role_attach_cni_policy", lookup(var.fargate_profile_defaults, "iam_role_attach_cni_policy", true))
-  iam_role_additional_policies  = lookup(each.value, "iam_role_additional_policies", lookup(var.fargate_profile_defaults, "iam_role_additional_policies", {}))
+  iam_role_additional_policies  = merge(
+    lookup(each.value, "iam_role_additional_policies", lookup(var.fargate_profile_defaults, "iam_role_additional_policies", {})),
+    var.create_fargate_logging_policy ? { fargate_logging = aws_iam_policy.fargate_logging[0].arn } : {},
+  )
   iam_role_tags                 = lookup(each.value, "iam_role_tags", {})
   tags                          = merge(var.tags, lookup(each.value, "tags", {}))
 }

--- a/modules/fargate_profile/variables.tf
+++ b/modules/fargate_profile/variables.tf
@@ -63,10 +63,16 @@ variable "fargate_log_group_retention_days" {
   default     = 90
 }
 
-variable "fargate_log_stream_prefix" {
-  description = "Log stream prefix"
+variable "create_fargate_logging_policy" {
+  description = "Create and attach fargate logging policy"
+  type        = bool
+  default     = true
+}
+
+variable "fargate_logging_policy_suffix" {
+  description = "Name of Fargate Logging Policy"
   type        = string
-  default     = ""
+  default     = "fargate-logging"
 }
 
 ##################################

--- a/variables.tf
+++ b/variables.tf
@@ -359,9 +359,3 @@ variable "create_fargate_logger_configmap" {
   type        = bool
   default     = true
 }
-
-variable "fargate_logging_policy" {
-  description = "Name of Fargate Logging Policy"
-  type        = string
-  default     = "fargate_logging_cloudwatch_default"
-}


### PR DESCRIPTION
- Manage IAM policy as part of fargate module
- Fix mixture of C and Golang plugin options

C plugin is `cloudwatch_logs`: https://docs.fluentbit.io/manual/v/1.5/pipeline/outputs/cloudwatch
Go plugin is `cloudwatch`: https://github.com/aws/amazon-cloudwatch-logs-for-fluent-bit
