### PR TITLE
fix syntax of fluent-bit output for cloudwatch

### DIFF
--- a/modules/essentials/templates/fluent_bit.yaml
+++ b/modules/essentials/templates/fluent_bit.yaml
@@ -110,7 +110,7 @@ config:
         Match kube.*
         region ap-southeast-1
         log_group_name ${log_group_name}
-        log_stream_template $(kubernetes['namespace_name'])/$(kubernetes['pod_name'])/$(kubernetes['container_name'])
+        log_stream_template $kubernetes['namespace_name'].$kubernetes['pod_name'].$kubernetes['container_name']
         log_stream_prefix fluentbit-
         auto_create_group false
 


### PR DESCRIPTION
characters that can separate template variables- only dots and commas (`.` and `,`) can come after a template variable.
<img width="1341" alt="Screenshot 2023-09-18 at 1 19 33 PM" src="https://github.com/SPHTech-Platform/terraform-aws-eks/assets/89894943/97b506b1-3e1a-41ae-a69a-ac809ee8001c">

reference: https://docs.fluentbit.io/manual/pipeline/outputs/cloudwatch#limitations-of-record_accessor-syntax