### PR TITLE
fix: Terraform aws provider still doesn't support pod identity associations for eks addons

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -67,7 +67,7 @@ resource "aws_iam_service_linked_role" "autoscaling" {
 # IRSA for addon components
 ############################
 module "vpc_cni_irsa_role" {
-  count = !var.enable_pod_identity ? 1 : 0
+  count = !var.enable_pod_identity_for_eks_addons ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.47"
@@ -90,7 +90,7 @@ module "vpc_cni_irsa_role" {
 }
 
 module "ebs_csi_irsa_role" {
-  count = !var.enable_pod_identity ? 1 : 0
+  count = !var.enable_pod_identity_for_eks_addons ? 1 : 0
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
   version = "~> 5.47"
@@ -111,7 +111,7 @@ module "ebs_csi_irsa_role" {
 }
 
 resource "aws_iam_role_policy" "ebs_csi_kms" {
-  count = !var.enable_pod_identity ? 1 : 0
+  count = !var.enable_pod_identity_for_eks_addons ? 1 : 0
 
   name_prefix = "kms"
   role        = module.ebs_csi_irsa_role[0].iam_role_name
@@ -123,7 +123,7 @@ resource "aws_iam_role_policy" "ebs_csi_kms" {
 ## Pod Identity Roles for Add-ons ##
 ####################################
 module "aws_vpc_cni_pod_identity" {
-  count = var.enable_pod_identity ? 1 : 0
+  count = var.enable_pod_identity_for_eks_addons ? 1 : 0
 
   source  = "terraform-aws-modules/eks-pod-identity/aws"
   version = "~> 1.5.0"
@@ -144,7 +144,7 @@ module "aws_vpc_cni_pod_identity" {
 }
 
 module "aws_ebs_csi_pod_identity" {
-  count = var.enable_pod_identity ? 1 : 0
+  count = var.enable_pod_identity_for_eks_addons ? 1 : 0
 
   source  = "terraform-aws-modules/eks-pod-identity/aws"
   version = "~> 1.5.0"

--- a/main.tf
+++ b/main.tf
@@ -72,7 +72,7 @@ module "eks" {
       most_recent                 = true
       resolve_conflicts_on_update = "OVERWRITE"
     }
-    vpc-cni = var.fargate_cluster && var.enable_pod_identity ? merge(local.addon_vpc_cni_pod_identity, {
+    vpc-cni = var.fargate_cluster && var.enable_pod_identity_for_eks_addons ? merge(local.addon_vpc_cni_pod_identity, {
       configuration_values = jsonencode({
         env = {
           # Reference doc: https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html#security-groups-pods-deployment
@@ -99,10 +99,10 @@ module "eks" {
             }
           }
         })
-        }) : (var.enable_pod_identity ? local.addon_vpc_cni_pod_identity : merge(local.addon_vpc_cni_pod_identity, {
+        }) : (var.enable_pod_identity_for_eks_addons ? local.addon_vpc_cni_pod_identity : merge(local.addon_vpc_cni_pod_identity, {
           service_account_role_arn = module.vpc_cni_irsa_role[0].iam_role_arn
     })))
-    aws-ebs-csi-driver = var.enable_pod_identity ? {
+    aws-ebs-csi-driver = var.enable_pod_identity_for_eks_addons ? {
       most_recent                 = true
       resolve_conflicts_on_update = "OVERWRITE"
       } : {

--- a/variables.tf
+++ b/variables.tf
@@ -614,12 +614,6 @@ variable "karpenter_upgrade" {
   default     = false
 }
 
-variable "enable_pod_identity" {
-  description = "Enable pod identity"
-  type        = bool
-  default     = true
-}
-
 variable "enable_pod_identity_for_karpenter" {
   description = "Enable pod identity for karpenter"
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -626,6 +626,12 @@ variable "enable_pod_identity_for_karpenter" {
   default     = false
 }
 
+variable "enable_pod_identity_for_eks_addons" {
+  description = "Enable pod identity for eks addons, Note - Default is `false` because AWS Terraform Provider still DOESN'T Support Pod Identity Association for EKS Addons"
+  type        = bool
+  default     = false
+}
+
 ################################################################################
 # Access Entry
 ################################################################################


### PR DESCRIPTION
feature request on this bug on provider repo: https://github.com/hashicorp/terraform-provider-aws/issues/38357

temporally disabling the pod identity association for EKS Addons, will use IRSA still this feature available  