### PR TITLE
feat: move karpenter secuity group selector from id to tags

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -12,10 +12,11 @@ locals {
         }
       ]
       karpenter_node_role = aws_iam_role.workers.name
-      karpenter_security_group_selector_maps = flatten(concat([{
-        "id" = module.eks.cluster_primary_security_group_id
-        }, local.additional_karpenter_security_group_id_maps
-      ]))
+      karpenter_security_group_selector_maps = [{
+        tags = merge({
+          "karpenter.sh/discovery" = module.eks.cluster_name
+        }, var.additional_karpenter_security_group_selector_tags)
+      }]
       karpenter_node_metadata_options = {
         httpEndpoint            = "enabled"
         httpProtocolIPv6        = var.cluster_ip_family != "ipv6" ? "disabled" : "enabled"
@@ -53,12 +54,6 @@ locals {
       ]
     },
   ])
-
-  additional_karpenter_security_group_id_maps = [
-    for val in var.additional_karpenter_security_group_ids : {
-      "id" = val
-    }
-  ]
 
   # Kaprenter Upgrade
   karpenter_upgrade_nodeclasses = concat([

--- a/main.tf
+++ b/main.tf
@@ -73,6 +73,10 @@ locals {
     }
   }
   addon_aws_ebs_csi_driver_lookup = var.enable_pod_identity_for_eks_addons ? "pod_identity" : "irsa"
+
+  node_security_group_tags = merge({
+    "karpenter.sh/discovery" = var.cluster_name
+  }, var.node_security_group_tags)
 }
 #tfsec:ignore:aws-eks-no-public-cluster-access-to-cidr
 #tfsec:ignore:aws-eks-no-public-cluster-access
@@ -130,6 +134,7 @@ module "eks" {
     }
   }, var.node_security_group_additional_rules)
   node_security_group_enable_recommended_rules = var.node_security_group_enable_recommended_rules
+  node_security_group_tags                     = local.node_security_group_tags
 
   create_kms_key = false # Created in kms.tf
   cluster_encryption_config = {

--- a/variables.tf
+++ b/variables.tf
@@ -195,6 +195,12 @@ variable "create_node_security_group" {
   default     = true
 }
 
+variable "node_security_group_tags" {
+  description = "A map of additional tags to add to the node security group created"
+  type        = map(string)
+  default     = {}
+}
+
 variable "worker_security_group_name" {
   description = "Worker security group name"
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -576,10 +576,10 @@ variable "karpenter_default_subnet_selector_tags" {
   }
 }
 
-variable "additional_karpenter_security_group_ids" {
-  description = "Additional security group IDs to add to the Karpenter node groups"
-  type        = list(string)
-  default     = []
+variable "additional_karpenter_security_group_selector_tags" {
+  description = "Additional security group tags to add to the Karpenter node groups"
+  type        = map(string)
+  default     = {}
 }
 
 variable "karpenter_pod_resources" {


### PR DESCRIPTION
karpenter auto discover, security groups with matching tags, no need to pass the the SG Ids for NodeClass