### PR TITLE
[PFMENG-2991] - Updating the Port Type of Fluentbit Readiness and Liveness Probe Variable

### DIFF
--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -1511,7 +1511,7 @@ variable "fluent_bit_liveness_probe" {
   default = {
     httpGet = {
       path = "/"
-      port = "2020"
+      port = 2020
     }
   }
 }
@@ -1522,7 +1522,7 @@ variable "fluent_bit_readiness_probe" {
   default = {
     httpGet = {
       path = "/api/v1/health"
-      port = "2020"
+      port = 2020
     }
   }
 }


### PR DESCRIPTION
[PFMENG-2991] - Updating the Port Type of Fluentbit Readiness and Liveness Probe Variable

[PFMENG-2991]: https://sph.atlassian.net/browse/PFMENG-2991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ