### PR TITLE
fix: fargate node security group policy perpetual drift (PFMENG-5178)

### DIFF
--- a/fargate_profile.tf
+++ b/fargate_profile.tf
@@ -65,8 +65,8 @@ resource "kubernetes_manifest" "fargate_node_security_group_policy" {
       namespace = each.value
     }
     spec = {
-      podSelector = {
-        matchExpressions = each.value == "kube-system" ? concat(
+      podSelector = each.value == "kube-system" ? {
+        matchExpressions = concat(
           length(var.fargate_security_group_policy_excluded_apps) > 0 ? [
             {
               key      = "app"
@@ -88,9 +88,9 @@ resource "kubernetes_manifest" "fargate_node_security_group_policy" {
               values   = var.fargate_security_group_policy_excluded_names
             }
           ] : []
-        ) : null
-
-        matchLabels = each.value == "kube-system" ? null : {}
+        )
+        } : {
+        matchLabels = {}
       }
       securityGroups = {
         groupIds = [tostring(module.eks.node_security_group_id)]

--- a/fargate_profile.tf
+++ b/fargate_profile.tf
@@ -65,33 +65,36 @@ resource "kubernetes_manifest" "fargate_node_security_group_policy" {
       namespace = each.value
     }
     spec = {
-      podSelector = each.value == "kube-system" ? {
-        matchExpressions = concat(
-          length(var.fargate_security_group_policy_excluded_apps) > 0 ? [
-            {
-              key      = "app"
-              operator = "NotIn"
-              values   = var.fargate_security_group_policy_excluded_apps
-            }
-          ] : [],
-          length(var.fargate_security_group_policy_excluded_k8s_apps) > 0 ? [
-            {
-              key      = "k8s-app"
-              operator = "NotIn"
-              values   = var.fargate_security_group_policy_excluded_k8s_apps
-            }
-          ] : [],
-          length(var.fargate_security_group_policy_excluded_names) > 0 ? [
-            {
-              key      = "app.kubernetes.io/name"
-              operator = "NotIn"
-              values   = var.fargate_security_group_policy_excluded_names
-            }
-          ] : []
-        )
-        } : {
-        matchLabels = {}
-      }
+      podSelector = merge(
+        each.value == "kube-system" ? {
+          matchExpressions = concat(
+            length(var.fargate_security_group_policy_excluded_apps) > 0 ? [
+              {
+                key      = "app"
+                operator = "NotIn"
+                values   = var.fargate_security_group_policy_excluded_apps
+              }
+            ] : [],
+            length(var.fargate_security_group_policy_excluded_k8s_apps) > 0 ? [
+              {
+                key      = "k8s-app"
+                operator = "NotIn"
+                values   = var.fargate_security_group_policy_excluded_k8s_apps
+              }
+            ] : [],
+            length(var.fargate_security_group_policy_excluded_names) > 0 ? [
+              {
+                key      = "app.kubernetes.io/name"
+                operator = "NotIn"
+                values   = var.fargate_security_group_policy_excluded_names
+              }
+            ] : []
+          )
+        } : {},
+        each.value != "kube-system" ? {
+          matchLabels = {}
+        } : {}
+      )
       securityGroups = {
         groupIds = [tostring(module.eks.node_security_group_id)]
       }


### PR DESCRIPTION
This PR fixes the perpetual drift in the `fargate_node_security_group_policy` `kubernetes_manifest` resource.

The root cause was the explicit use of `null` for `matchExpressions` or `matchLabels`, which the Kubernetes API returns differently, leading to a drift in every Terraform run.

Jira Story: [PFMENG-5178](https://sph.atlassian.net/browse/PFMENG-5178)

[PFMENG-5178]: https://sph.atlassian.net/browse/PFMENG-5178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ