### PR TITLE
[PFMENG-5308] fix: karpenter EC2NodeClass to use the standardized eks:eks-cluster-name tag

### DIFF
--- a/karpenter.tf
+++ b/karpenter.tf
@@ -25,7 +25,7 @@ locals {
       karpenter_node_user_data = ""
       karpenter_node_tags_map = {
         "karpenter.sh/discovery" = module.eks.cluster_name,
-        "eks:cluster-name"       = module.eks.cluster_name,
+        "eks:eks-cluster-name"   = module.eks.cluster_name,
       }
       karpenter_block_device_mapping = [
         {


### PR DESCRIPTION
…:eks-cluster-name tag