### PR TITLE
[PFMENG-5378] Maintenance: Weekly dependency update (S3 and Fluent Bit)

### DIFF
--- a/modules/essentials/fluent_bit_s3.tf
+++ b/modules/essentials/fluent_bit_s3.tf
@@ -2,7 +2,7 @@ module "fluentbit_s3_bucket" {
   count = var.fluent_bit_enable_s3_output ? 1 : 0
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "~> 5.8.2"
+  version = "~> 5.12.0"
 
   bucket = "fluentbit-log-bucket-${random_string.s3_suffix.result}"
 

--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -1527,8 +1527,6 @@ variable "fluent_bit_readiness_probe" {
   }
 }
 
-
-
 variable "fluent_bit_resources" {
   description = "Resources for fluent-bit"
   type        = map(any)

--- a/modules/essentials/variables.tf
+++ b/modules/essentials/variables.tf
@@ -1432,7 +1432,7 @@ variable "fluent_bit_helm_config_defaults" {
     name        = "fluent-bit"
     chart       = "fluent-bit"
     repository  = "https://fluent.github.io/helm-charts"
-    version     = "0.57.2"
+    version     = "0.57.3"
     namespace   = "logging"
     description = "Fluent Bit helm Chart deployment configuration"
   }
@@ -1521,11 +1521,13 @@ variable "fluent_bit_readiness_probe" {
   type        = map(any)
   default = {
     httpGet = {
-      path = "/api/v1/health"
+      path = "/api/v2/health"
       port = 2020
     }
   }
 }
+
+
 
 variable "fluent_bit_resources" {
   description = "Resources for fluent-bit"


### PR DESCRIPTION
This PR updates external dependencies to their latest stable versions.

### **Jira Story**
[PFMENG-5378](https://sph.atlassian.net/browse/PFMENG-5378)

### **Task Breakdown**
- [x] **[PFMENG-5381]** Update S3 Bucket module (v5.12.0)
- [x] **[PFMENG-5379]** Update Fluent Bit Helm chart (v0.57.3) and sync readiness probe path
- [ ] (Skipped) Update IAM and Pod Identity modules (as requested by user)
- [ ] (Skipped) Update SQS module (as requested by user)

### **Changes**
- \`terraform-aws-modules/s3-bucket/aws\`: Updated version constraint from \`~> 5.8.2\` to \`~> 5.12.0\`.
- \`fluent-bit\` Helm Chart: Updated default version from \`0.57.2\` to \`0.57.3\`.
- \`fluent_bit_readiness_probe\`: Updated default path from \`/api/v1/health\` to \`/api/v2/health\` to align with upstream changes.

[PFMENG-5378]: https://sph.atlassian.net/browse/PFMENG-5378?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PFMENG-5381]: https://sph.atlassian.net/browse/PFMENG-5381?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PFMENG-5379]: https://sph.atlassian.net/browse/PFMENG-5379?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ