### PR TITLE
[PFMENG-5472] Fix: Default to inline IAM policy for Karpenter controller

### DIFF
--- a/modules/karpenter/irsa.tf
+++ b/modules/karpenter/irsa.tf
@@ -471,8 +471,17 @@ resource "aws_iam_role" "controller" {
   tags = merge(var.tags, var.iam_role_tags)
 }
 
+resource "aws_iam_role_policy" "controller" {
+  count = var.enable_irsa && var.enable_inline_policy ? 1 : 0
+
+  name        = var.iam_policy_use_name_prefix ? null : var.iam_policy_name
+  name_prefix = var.iam_policy_use_name_prefix ? "${var.iam_policy_name}-" : null
+  role        = aws_iam_role.controller[0].name
+  policy      = data.aws_iam_policy_document.controller[0].json
+}
+
 resource "aws_iam_policy" "controller" {
-  count = var.enable_irsa ? 1 : 0
+  count = var.enable_irsa && !var.enable_inline_policy ? 1 : 0
 
   name        = var.iam_policy_use_name_prefix ? null : var.iam_policy_name
   name_prefix = var.iam_policy_use_name_prefix ? "${var.iam_policy_name}-" : null
@@ -484,7 +493,7 @@ resource "aws_iam_policy" "controller" {
 }
 
 resource "aws_iam_role_policy_attachment" "controller" {
-  count = var.enable_irsa ? 1 : 0
+  count = var.enable_irsa && !var.enable_inline_policy ? 1 : 0
 
   role       = aws_iam_role.controller[0].name
   policy_arn = aws_iam_policy.controller[0].arn

--- a/modules/karpenter/variables.tf
+++ b/modules/karpenter/variables.tf
@@ -287,7 +287,7 @@ variable "enable_irsa" {
 variable "enable_inline_policy" {
   description = "Determines whether the controller policy is created as a standard IAM policy or inline IAM policy. This can be enabled when the error `LimitExceeded: Cannot exceed quota for PolicySize: 6144` is received since standard IAM policies have a limit of 6,144 characters versus an inline role policy's limit of 10,240 ([Reference](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html))"
   type        = bool
-  default     = false
+  default     = true
 }
 
 variable "oidc_provider_arn" {


### PR DESCRIPTION
## Jira Ticket
[PFMENG-5472](https://sph.atlassian.net/browse/PFMENG-5472)

## Description
This PR updates the Karpenter module to default to using an inline IAM policy for the controller role. 
This is a proactive measure to avoid the `LimitExceeded: Cannot exceed quota for PolicySize: 6144` error, 
as inline policies have a higher character limit (10,240).

## Task Breakdown
- Set `enable_inline_policy` default to `true` in `variables.tf`.
- Update `irsa.tf` to conditionally create `aws_iam_role_policy` (inline) or `aws_iam_policy` (standard) based on the `enable_inline_policy` variable.

[PFMENG-5472]: https://sph.atlassian.net/browse/PFMENG-5472?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ