### PR TITLE
[PFMENG-5500] Fix: KEDA Scaling Enhancements and IRSA Stability Fixes

### DIFF
--- a/modules/essentials/scaling.tf
+++ b/modules/essentials/scaling.tf
@@ -64,6 +64,11 @@ locals {
       kind      = "Deployment"
       replicas  = 1
       enabled   = true
+      advanced = {
+        horizontalPodAutoscalerConfig = {
+          name = "aws-load-balancer-controller"
+        }
+      }
       triggers = [
         {
           type = "cron"
@@ -95,6 +100,7 @@ locals {
       max_replicas   = try(t.max_replicas, t.replicas, 1)
       scaled_object  = try(t.scaled_object, null)
       authentication = try(t.authentication, null)
+      advanced       = try(t.advanced, null)
       triggers = try(t.triggers, [
         {
           type = "cron"
@@ -115,6 +121,7 @@ locals {
       max_replicas   = try(t.max_replicas, t.replicas, 1)
       scaled_object  = try(t.scaled_object, null)
       authentication = try(t.authentication, null)
+      advanced       = try(t.advanced, null)
       triggers = try(t.triggers, [
         {
           type = "cron"
@@ -154,7 +161,10 @@ resource "kubernetes_manifest" "system_scaled_objects" {
       minReplicaCount = each.value.min_replicas
       maxReplicaCount = each.value.max_replicas
       triggers        = each.value.triggers
-    }, each.value.authentication != null ? { authenticationRef = each.value.authentication } : {})
+      },
+      each.value.authentication != null ? { authenticationRef = each.value.authentication } : {},
+      each.value.advanced != null ? { advanced = each.value.advanced } : {}
+    )
   }
 
   depends_on = [helm_release.keda]


### PR DESCRIPTION
## Jira Ticket
[PFMENG-5500](https://sph.atlassian.net/browse/PFMENG-5500)

## Description
This PR introduces critical enhancements to KEDA scaling flexibility and stability fixes for IRSA role creation in secure environments.

## Task Breakdown
- **Polymorphic KEDA scaling**: Refactored `keda_additional_scaling_targets` to use `any` type and `try()` logic, allowing mixed object structures (legacy vs advanced) in the same list.
- **HPA Ownership Transfer**: Added support for `advanced` settings in KEDA `ScaledObject` manifests to enable adoption of existing HPAs.
- **Fluent Bit IRSA Fix**: Wrapped the Fluent Bit IRSA role name with `nonsensitive()` to break the sensitivity chain from cluster name outputs.

## Validation
Successfully verified in the `dstf-bt-drupal-infra-uat` environment. All security policies (Sentinel) passed.

[PFMENG-5500]: https://sph.atlassian.net/browse/PFMENG-5500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ